### PR TITLE
Fix existentials for higher kinded types

### DIFF
--- a/cipher-symmetric/src/main/scala/tsec/cipher/symmetric/imports/package.scala
+++ b/cipher-symmetric/src/main/scala/tsec/cipher/symmetric/imports/package.scala
@@ -27,7 +27,7 @@ package object imports{
     def is[A]: Is[KeyRepr[A], JSecretKey]
   }
 
-  val SecretKey$$: TaggedSecretKey = new TaggedSecretKey {
+  protected val SecretKey$$: TaggedSecretKey = new TaggedSecretKey {
     type KeyRepr[A] = Id[JSecretKey]
     @inline def is[A]: Is[KeyRepr[A], JSecretKey] = Is.refl[JSecretKey]
   }

--- a/cipher-symmetric/src/main/scala/tsec/cipher/symmetric/imports/package.scala
+++ b/cipher-symmetric/src/main/scala/tsec/cipher/symmetric/imports/package.scala
@@ -1,7 +1,5 @@
 package tsec.cipher.symmetric
 
-import javax.crypto
-
 import tsec.cipher.common._
 import tsec.cipher.common.mode.GCM
 import tsec.cipher.common.padding.NoPadding

--- a/cipher-symmetric/src/main/scala/tsec/cipher/symmetric/imports/package.scala
+++ b/cipher-symmetric/src/main/scala/tsec/cipher/symmetric/imports/package.scala
@@ -1,11 +1,14 @@
 package tsec.cipher.symmetric
 
+import javax.crypto
+
 import tsec.cipher.common._
 import tsec.cipher.common.mode.GCM
 import tsec.cipher.common.padding.NoPadding
 import tsec.common.{CryptoTag, JKeyGenerator}
 import javax.crypto.{SecretKey => JSecretKey}
 
+import cats.Id
 import cats.evidence.Is
 
 package object imports{
@@ -22,16 +25,16 @@ package object imports{
   protected[tsec] case class SymmetricAlgorithm[T](algorithm: String, keyLength: Int) extends CryptoTag[T]
 
   sealed trait TaggedSecretKey {
-    type KeyRepr
-    val is: Is[KeyRepr, JSecretKey]
+    type KeyRepr[A]
+    def is[A]: Is[KeyRepr[A], JSecretKey]
   }
 
   val SecretKey$$: TaggedSecretKey = new TaggedSecretKey {
-    type KeyRepr = JSecretKey
-    val is = Is.refl[JSecretKey]
+    type KeyRepr[A] = Id[JSecretKey]
+    @inline def is[A]: Is[KeyRepr[A], JSecretKey] = Is.refl[JSecretKey]
   }
 
-  type SecretKey[A] = SecretKey$$.KeyRepr
+  type SecretKey[A] = SecretKey$$.KeyRepr[A]
 
   object SecretKey {
     @inline def apply[A: SymmetricAlgorithm](key: JSecretKey): SecretKey[A] = SecretKey$$.is.flip.coerce(key)

--- a/cipher-symmetric/src/main/scala/tsec/cipher/symmetric/imports/package.scala
+++ b/cipher-symmetric/src/main/scala/tsec/cipher/symmetric/imports/package.scala
@@ -6,7 +6,6 @@ import tsec.cipher.common.padding.NoPadding
 import tsec.common.{CryptoTag, JKeyGenerator}
 import javax.crypto.{SecretKey => JSecretKey}
 
-import cats.Id
 import cats.evidence.Is
 
 package object imports{
@@ -28,7 +27,7 @@ package object imports{
   }
 
   protected val SecretKey$$: TaggedSecretKey = new TaggedSecretKey {
-    type KeyRepr[A] = Id[JSecretKey]
+    type KeyRepr[A] = JSecretKey
     @inline def is[A]: Is[KeyRepr[A], JSecretKey] = Is.refl[JSecretKey]
   }
 

--- a/mac/src/main/scala/tsec/mac/imports/package.scala
+++ b/mac/src/main/scala/tsec/mac/imports/package.scala
@@ -4,8 +4,6 @@ import cats.evidence.Is
 import tsec.common._
 import javax.crypto.{SecretKey => JSecretKey}
 
-import cats.Id
-
 package object imports {
 
   type MacErrorM[A] = Either[Throwable, A]
@@ -74,7 +72,7 @@ package object imports {
   }
 
   protected val MacSigningKey$$: TaggedMacKey = new TaggedMacKey {
-    type Repr[A] = Id[JSecretKey]
+    type Repr[A] = JSecretKey
     @inline def is[A]: Is[Repr[A], JSecretKey] = Is.refl[JSecretKey]
   }
 

--- a/mac/src/main/scala/tsec/mac/imports/package.scala
+++ b/mac/src/main/scala/tsec/mac/imports/package.scala
@@ -88,4 +88,6 @@ package object imports {
   final class SigningKeyOps[A](val key: MacSigningKey[A]) extends AnyVal {
     def toJavaKey: JSecretKey = MacSigningKey$$.is.coerce(key)
   }
+
+  implicit final def _macSigningOps[A](key: MacSigningKey[A]) = new SigningKeyOps[A](key)
 }

--- a/signatures/src/main/scala/tsec/signature/imports/package.scala
+++ b/signatures/src/main/scala/tsec/signature/imports/package.scala
@@ -2,6 +2,7 @@ package tsec.signature
 
 import java.security.KeyPairGenerator
 
+import cats.Id
 import tsec.common._
 import cats.evidence.Is
 import tsec.signature.core.SigAlgoTag
@@ -270,54 +271,54 @@ package object imports {
   import java.security.PublicKey
 
   sealed trait TaggedCertificate {
-    type Repr
-    val is: Is[Repr, Certificate]
+    type Repr[A]
+    def is[A]: Is[Repr[A], Certificate]
   }
 
   protected val SigCertificate$$ : TaggedCertificate = new TaggedCertificate {
-    type Repr = Certificate
-    val is = Is.refl[Certificate]
+    type Repr[A] = Id[Certificate]
+    @inline def is[A]: Is[Repr[A], Certificate] = Is.refl[Certificate]
   }
 
-  type SigCertificate[A] = SigCertificate$$.Repr
+  type SigCertificate[A] = SigCertificate$$.Repr[A]
 
   object SigCertificate {
-    @inline def apply[A: SigAlgoTag](cert: Certificate): SigCertificate[A] = SigCertificate$$.is.flip.coerce(cert)
-    @inline def toJavaCertificate[A](cert: SigCertificate[A]): Certificate = SigCertificate$$.is.coerce(cert)
+    @inline def apply[A: SigAlgoTag](cert: Certificate): SigCertificate[A] = SigCertificate$$.is[A].flip.coerce(cert)
+    @inline def toJavaCertificate[A](cert: SigCertificate[A]): Certificate = SigCertificate$$.is[A].coerce(cert)
   }
 
   sealed trait TaggedSigPubKey {
-    type Repr
-    val is: Is[Repr, PublicKey]
+    type Repr[A]
+    def is[A]: Is[Repr[A], PublicKey]
   }
 
   protected val SigPubKey$$: TaggedSigPubKey = new TaggedSigPubKey {
-    type Repr = PublicKey
-    val is = Is.refl[PublicKey]
+    type Repr[A] = Id[PublicKey]
+    def is[A]: Is[Repr[A], PublicKey] = Is.refl[PublicKey]
   }
 
-  type SigPublicKey[A] = SigPubKey$$.Repr
+  type SigPublicKey[A] = SigPubKey$$.Repr[A]
 
   object SigPublicKey {
-    @inline def apply[A: SigAlgoTag](key: PublicKey): SigPublicKey[A] = SigPubKey$$.is.flip.coerce(key)
-    @inline def toJavaPublicKey[A](key: SigPublicKey[A]): PublicKey = SigPubKey$$.is.coerce(key)
+    @inline def apply[A: SigAlgoTag](key: PublicKey): SigPublicKey[A] = SigPubKey$$.is[A].flip.coerce(key)
+    @inline def toJavaPublicKey[A](key: SigPublicKey[A]): PublicKey = SigPubKey$$.is[A].coerce(key)
   }
 
   sealed trait TaggedSigPrivateKey {
-    type Repr
-    val is: Is[Repr, PrivateKey]
+    type Repr[A]
+    def is[A]: Is[Repr[A], PrivateKey]
   }
 
   protected val SigPrivateKey$$: TaggedSigPrivateKey = new TaggedSigPrivateKey {
-    type Repr = PrivateKey
-    val is = Is.refl[PrivateKey]
+    type Repr[A] = Id[PrivateKey]
+    @inline def is[A]: Is[Repr[A], PrivateKey] = Is.refl[PrivateKey]
   }
 
-  type SigPrivateKey[A] = SigPrivateKey$$.Repr
+  type SigPrivateKey[A] = SigPrivateKey$$.Repr[A]
 
   object SigPrivateKey {
-    @inline def apply[A: SigAlgoTag](key: PrivateKey): SigPrivateKey[A] = SigPrivateKey$$.is.flip.coerce(key)
-    @inline def toJavaPrivateKey[A](key: SigPrivateKey[A]): PrivateKey = SigPrivateKey$$.is.coerce(key)
+    @inline def apply[A: SigAlgoTag](key: PrivateKey): SigPrivateKey[A] = SigPrivateKey$$.is[A].flip.coerce(key)
+    @inline def toJavaPrivateKey[A](key: SigPrivateKey[A]): PrivateKey = SigPrivateKey$$.is[A].coerce(key)
   }
 
 }

--- a/signatures/src/main/scala/tsec/signature/imports/package.scala
+++ b/signatures/src/main/scala/tsec/signature/imports/package.scala
@@ -2,7 +2,6 @@ package tsec.signature
 
 import java.security.KeyPairGenerator
 
-import cats.Id
 import tsec.common._
 import cats.evidence.Is
 import tsec.signature.core.SigAlgoTag
@@ -276,7 +275,7 @@ package object imports {
   }
 
   protected val SigCertificate$$ : TaggedCertificate = new TaggedCertificate {
-    type Repr[A] = Id[Certificate]
+    type Repr[A] = Certificate
     @inline def is[A]: Is[Repr[A], Certificate] = Is.refl[Certificate]
   }
 
@@ -293,7 +292,7 @@ package object imports {
   }
 
   protected val SigPubKey$$: TaggedSigPubKey = new TaggedSigPubKey {
-    type Repr[A] = Id[PublicKey]
+    type Repr[A] = PublicKey
     def is[A]: Is[Repr[A], PublicKey] = Is.refl[PublicKey]
   }
 
@@ -310,7 +309,7 @@ package object imports {
   }
 
   protected val SigPrivateKey$$: TaggedSigPrivateKey = new TaggedSigPrivateKey {
-    type Repr[A] = Id[PrivateKey]
+    type Repr[A] = PrivateKey
     @inline def is[A]: Is[Repr[A], PrivateKey] = Is.refl[PrivateKey]
   }
 


### PR DESCRIPTION
Previous to this patch, this code compiled:

```scala
import tsec.cipher.symmetric.imports._

def g(secretKey: SecretKey[AES128]) = secretKey

g(AES192.generateKeyUnsafe())
```

This clearly violates some of what we're trying to do, which is protect library consumers from shooting themselves in the foot by making the compiler work for them.

In particular, it had to do with the definition of `SecretKey`, which parametrized over a type like such:

```scala
type SecretKey[A] = SecretKey$$.KeyRepr
```

My guess is, the compiler could prove `SecretKey[A] === SecretKey[B]` for all A and B given the refinement gave `SecretKey$$.KeyRepr === SecretKey$$.KeyRepr`. By adding a type parameter over the abstract type itself, using `cats.Id` and parametrizing the `Is` evidence to be polymorphic, we can ensure the refinement `SecretKey[A] !== SecretKey[B]`