### PR TITLE
M4 breaking changes (Don't merge yet)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -38,7 +38,8 @@ lazy val commonSettings = Seq(
     Libraries.cats,
     Libraries.catsEffect,
     Libraries.scalaTest,
-    Libraries.scalaCheck
+    Libraries.scalaCheck,
+    Libraries.commonsCodec
   ),
   organization in ThisBuild := "io.github.jmcardon",
   scalaVersion in ThisBuild := "2.12.3",

--- a/build.sbt
+++ b/build.sbt
@@ -189,6 +189,7 @@ lazy val http4s = Project(id = "tsec-http4s", base = file("tsec-http4s"))
     symmetricCipher,
     mac,
     messageDigests,
+    passwordHashers,
     jwtMac
   )
 

--- a/build.sbt
+++ b/build.sbt
@@ -42,7 +42,7 @@ lazy val commonSettings = Seq(
     Libraries.commonsCodec
   ),
   organization in ThisBuild := "io.github.jmcardon",
-  scalaVersion in ThisBuild := "2.12.3",
+  scalaVersion in ThisBuild := "2.12.4",
   fork in test := true,
   parallelExecution in test := false,
   addCompilerPlugin("org.spire-math" %% "kind-projector" % "0.9.4"),

--- a/cipher-symmetric/src/main/scala/tsec/cipher/symmetric/imports/aead/JCAAEADPure.scala
+++ b/cipher-symmetric/src/main/scala/tsec/cipher/symmetric/imports/aead/JCAAEADPure.scala
@@ -157,7 +157,7 @@ object JCAAEADPure {
       queueLen: Int
   ): JQueue[JCipher] = {
     val q = new JQueue[JCipher]()
-    (0 until queueLen)
+    Array.range(0, queueLen)
       .foreach(
         _ => q.add(getJCipherUnsafe)
       )

--- a/cipher-symmetric/src/main/scala/tsec/cipher/symmetric/mode/CipherModes.scala
+++ b/cipher-symmetric/src/main/scala/tsec/cipher/symmetric/mode/CipherModes.scala
@@ -44,7 +44,7 @@ trait CipherModes {
       /** Cache our random, and seed it properly as per
         * https://tersesystems.com/2015/12/17/the-right-way-to-use-securerandom/
         */
-      private val cachedRand: SecureRandom = {
+      private var cachedRand: SecureRandom = {
         val r = new SecureRandom()
         r.nextBytes(new Array[Byte](20))
         r
@@ -58,7 +58,9 @@ trait CipherModes {
 
       private def reSeed(): Unit = {
         adder.reset()
-        cachedRand.nextBytes(new Array[Byte](20))
+        val tmpRand = new SecureRandom()
+        tmpRand.nextBytes(new Array[Byte](20))
+        cachedRand = tmpRand
       }
 
       def algorithm: String = "GCM"
@@ -67,7 +69,7 @@ trait CipherModes {
 
       def genIv: ParameterSpec[GCM] = {
         adder.increment()
-        if (adder.sum() >= MaxBeforeReseed)
+        if (adder.sum() == MaxBeforeReseed)
           reSeed()
 
         val newBytes = new Array[Byte](12)

--- a/cipher-symmetric/src/main/scala/tsec/cipher/symmetric/mode/CipherModes.scala
+++ b/cipher-symmetric/src/main/scala/tsec/cipher/symmetric/mode/CipherModes.scala
@@ -38,17 +38,17 @@ trait CipherModes {
       *  Iv length of 96 bits is recommended as per the spec on page 8
       */
     val GCMTagLength        = 128
-    val GCMIvOptionalLength = 12
+    val GCMIVStandardLength = 12
     implicit lazy val spec = new AEADMode[GCM] with ManagedRandom { self =>
 
-      val ivLength: Int = GCMIvOptionalLength
+      val ivLength: Int = GCMIVStandardLength
 
       def algorithm: String = "GCM"
       def buildIvFromBytes(specBytes: Array[Byte]): ParameterSpec[GCM] =
         ParameterSpec.fromSpec[GCM](new GCMParameterSpec(GCMTagLength, specBytes))(self)
 
       def genIv: ParameterSpec[GCM] = {
-        val newBytes = new Array[Byte](12)
+        val newBytes = new Array[Byte](GCMIVStandardLength)
         nextBytes(newBytes)
         ParameterSpec.fromSpec[GCM](new GCMParameterSpec(GCMTagLength, newBytes))(self)
       }

--- a/cipher-symmetric/src/main/scala/tsec/cipher/symmetric/mode/package.scala
+++ b/cipher-symmetric/src/main/scala/tsec/cipher/symmetric/mode/package.scala
@@ -1,8 +1,9 @@
 package tsec.cipher.symmetric
 
 import java.security.spec.AlgorithmParameterSpec
+
 import cats.evidence.Is
-import tsec.common.CryptoTag
+import tsec.common.{CryptoTag, ManagedRandom}
 import java.security.SecureRandom
 import java.util.concurrent.atomic.LongAdder
 import javax.crypto.spec.IvParameterSpec
@@ -42,32 +43,10 @@ package object mode {
     */
   trait AEADMode[T] extends CipherMode[T]
 
-  abstract class DefaultModeKeySpec[T](repr: String, ivLen: Int) {
+  abstract class DefaultModeKeySpec[T](repr: String, ivLen: Int) extends ManagedRandom {
     implicit val spec = new CipherMode[T] { self =>
 
       val ivLength: Int = ivLen
-
-      /** Cache our random, and seed it properly as per
-        * https://tersesystems.com/2015/12/17/the-right-way-to-use-securerandom/
-        */
-      private var cachedRand: SecureRandom = {
-        val r = new SecureRandom()
-        r.nextBytes(new Array[Byte](20))
-        r
-      }
-
-      /** We will keep a reference to how many times our random is utilized
-        * After a sensible Integer.MaxValue/2 times, we should reseed
-        */
-      private val adder: LongAdder = new LongAdder
-      private val MaxBeforeReseed  = (Integer.MAX_VALUE / 5).toLong
-
-      private def reSeed(): Unit = {
-        adder.reset()
-        val tmpRand = new SecureRandom()
-        tmpRand.nextBytes(new Array[Byte](20))
-        cachedRand = tmpRand
-      }
 
       override lazy val algorithm: String = repr
 
@@ -75,12 +54,8 @@ package object mode {
         ParameterSpec.fromSpec[T](new IvParameterSpec(specBytes))(self)
 
       def genIv: ParameterSpec[T] = {
-        adder.increment()
-        if (adder.sum() == MaxBeforeReseed)
-          reSeed()
-
         val byteArray = new Array[Byte](ivLen)
-        cachedRand.nextBytes(byteArray)
+        nextBytes(byteArray)
         ParameterSpec.fromSpec[T](new IvParameterSpec(byteArray))(self)
       }
     }

--- a/common/src/main/scala/tsec/common/ByteUtils.scala
+++ b/common/src/main/scala/tsec/common/ByteUtils.scala
@@ -1,16 +1,9 @@
 package tsec.common
 
+import java.security.MessageDigest
+
 object ByteUtils {
   def constantTimeEquals(a: Array[Byte], b: Array[Byte]): Boolean =
-    if (a.length != b.length) false
-    else {
-      var nonEqual = 0
-      var i        = 0
-      while (i != a.length) {
-        nonEqual |= (a(i) ^ b(i))
-        i += 1
-      }
-      nonEqual == 0
-    }
+    MessageDigest.isEqual(a, b)
 
 }

--- a/common/src/main/scala/tsec/common/ManagedRandom.scala
+++ b/common/src/main/scala/tsec/common/ManagedRandom.scala
@@ -13,7 +13,7 @@ trait ManagedRandom {
     * https://tersesystems.com/2015/12/17/the-right-way-to-use-securerandom/
     * Random may block on linux machiens
     */
-  protected[tsec] var cachedRand: SecureRandom = {
+  private var cachedRand: SecureRandom = {
     val r = new SecureRandom()
     r.nextBytes(new Array[Byte](20))
     r

--- a/common/src/main/scala/tsec/common/ManagedRandom.scala
+++ b/common/src/main/scala/tsec/common/ManagedRandom.scala
@@ -1,0 +1,41 @@
+package tsec.common
+
+import java.security.SecureRandom
+import java.util.concurrent.atomic.LongAdder
+
+/** A trait that manages a secureRandom instance
+  * when
+  *
+  */
+trait ManagedRandom {
+
+  /** Cache our random, and seed it properly as per
+    * https://tersesystems.com/2015/12/17/the-right-way-to-use-securerandom/
+    * Random may block on linux machiens
+    */
+  protected[tsec] var cachedRand: SecureRandom = {
+    val r = new SecureRandom()
+    r.nextBytes(new Array[Byte](20))
+    r
+  }
+
+  /** We will keep a reference to how many times our random is utilized
+    * After a sensible Integer.MaxValue/5 times, we should reseed
+    */
+  private val adder: LongAdder = new LongAdder
+  private val MaxBeforeReseed  = (Integer.MAX_VALUE / 5).toLong
+
+  private def reSeed(): Unit = {
+    adder.reset()
+    val tmpRand = new SecureRandom()
+    tmpRand.nextBytes(new Array[Byte](20))
+    cachedRand = tmpRand
+  }
+
+  def nextBytes(bytes: Array[Byte]): Unit = {
+    adder.increment()
+    if (adder.sum() == MaxBeforeReseed)
+      reSeed()
+    cachedRand.nextBytes(bytes)
+  }
+}

--- a/common/src/main/scala/tsec/common/SecureRandomIdGenerator.scala
+++ b/common/src/main/scala/tsec/common/SecureRandomIdGenerator.scala
@@ -1,0 +1,17 @@
+package tsec.common
+
+import cats.evidence.Is
+import org.apache.commons.codec.binary.Hex
+
+case class SecureRandomIdGenerator(sizeInBytes: Int = 32) extends ManagedRandom {
+  def generate: SecureRandomId = {
+    val byteArray = new Array[Byte](sizeInBytes)
+    nextBytes(byteArray)
+    SecureRandomId$$.is.flip.coerce(Hex.encodeHexString(byteArray))
+  }
+}
+
+object SecureRandomId extends SecureRandomIdGenerator(32){
+  @inline def is: Is[SecureRandomId, String] = SecureRandomId$$.is
+  def coerce(s: String): SecureRandomId = is.flip.coerce(s)
+}

--- a/common/src/main/scala/tsec/common/package.scala
+++ b/common/src/main/scala/tsec/common/package.scala
@@ -36,7 +36,7 @@ package object common {
   }
 
   class TaggedByteSyntax[A](val repr: A) extends AnyVal {
-    def toArray(implicit byteEV: ByteEV[A]): Array[Byte] = byteEV.toArray(repr)
+    def asByteArray(implicit byteEV: ByteEV[A]): Array[Byte] = byteEV.toArray(repr)
   }
 
   class TaggedStringSyntax[A](val repr: A) extends AnyVal {
@@ -63,5 +63,12 @@ package object common {
   implicit final def costanzaOps(jerry: String)            = new JerryStringer(jerry)
   implicit final def taggedByteOps[A: ByteEV](repr: A)     = new TaggedByteSyntax[A](repr)
   implicit final def taggedStringOps[A: StringEV](repr: A) = new TaggedStringSyntax[A](repr)
+
+  protected [tsec] val SecureRandomId$$: TaggedString = new TaggedString {
+    type I = String
+    val is: Is[I, String] = Is.refl[I]
+  }
+
+  type SecureRandomId = SecureRandomId$$.I
 
 }

--- a/examples/src/main/scala/Http4sAuthExamples.scala
+++ b/examples/src/main/scala/Http4sAuthExamples.scala
@@ -103,7 +103,7 @@ object Http4sAuthExamples {
     )
 
   val Auth =
-    SecuredRequestHandler.encryptedCookie(encryptedCookieAuth)
+    SecuredRequestHandler(encryptedCookieAuth)
 
   val onlyAdmins      = BasicRBAC[IO, User, Role](Role.Administrator, Role.Customer)
   val adminsAndSeller = BasicRBAC[IO, User, Role](Role.Administrator, Role.Seller)

--- a/examples/src/main/scala/Http4sAuthExamples.scala
+++ b/examples/src/main/scala/Http4sAuthExamples.scala
@@ -1,40 +1,42 @@
 import java.util.UUID
+
 import cats._
 import cats.data.OptionT
-import cats.effect.IO
+import cats.effect.{IO, Sync}
 import org.http4s.HttpService
 import tsec.authentication._
 import tsec.authorization._
 import tsec.cipher.symmetric.imports._
+
 import scala.collection.mutable
 import scala.concurrent.duration._
 import org.http4s.dsl.io._
 
 
 object Http4sAuthExamples {
-  def dummyBackingStore[F[_], I, V](getId: V => I)(implicit F: Monad[F]) = new BackingStore[F, I, V] {
+  def dummyBackingStore[F[_], I, V](getId: V => I)(implicit F: Sync[F]) = new BackingStore[F, I, V] {
     private val storageMap = mutable.HashMap.empty[I, V]
 
-    def put(elem: V): F[Int] = {
+    def put(elem: V): F[V] = {
       val map = storageMap.put(getId(elem), elem)
       if (map.isEmpty)
-        F.pure(0)
+        F.pure(elem)
       else
-        F.pure(1)
+        F.raiseError(new IllegalArgumentException)
     }
 
     def get(id: I): OptionT[F, V] =
       OptionT.fromOption[F](storageMap.get(id))
 
-    def update(v: V): F[Int] = {
+    def update(v: V): F[V] = {
       storageMap.update(getId(v), v)
-      F.pure(1)
+      F.pure(v)
     }
 
-    def delete(id: I): F[Int] =
+    def delete(id: I): F[Unit] =
       storageMap.remove(id) match {
-        case Some(_) => F.pure(1)
-        case None    => F.pure(0)
+        case Some(_) => F.unit
+        case None    => F.raiseError(new IllegalArgumentException)
       }
   }
 

--- a/examples/src/main/scala/Http4sAuthExamples.scala
+++ b/examples/src/main/scala/Http4sAuthExamples.scala
@@ -61,8 +61,8 @@ object Http4sAuthExamples {
   case class User(id: Int, age: Int, name: String, role: Role = Role.Customer)
 
   object User {
-    implicit def authRole[F[_]](implicit F: MonadError[F, Throwable]): AuthorizationInfo[F, User, Role] =
-      new AuthorizationInfo[F, User, Role] {
+    implicit def authRole[F[_]](implicit F: MonadError[F, Throwable]): AuthorizationInfo[F, Role, User] =
+      new AuthorizationInfo[F, Role, User] {
         def fetchInfo(u: User): F[Role] = F.pure(u.role)
       }
   }
@@ -107,8 +107,8 @@ object Http4sAuthExamples {
   val Auth =
     SecuredRequestHandler(encryptedCookieAuth)
 
-  val onlyAdmins      = BasicRBAC[IO, User, Role](Role.Administrator, Role.Customer)
-  val adminsAndSeller = BasicRBAC[IO, User, Role](Role.Administrator, Role.Seller)
+  val onlyAdmins      = BasicRBAC[IO, Role, User](Role.Administrator, Role.Customer)
+  val adminsAndSeller = BasicRBAC[IO, Role, User](Role.Administrator, Role.Seller)
 
   /*
   Now from here, if want want to create services, we simply use the following

--- a/examples/src/main/scala/MacExamples.scala
+++ b/examples/src/main/scala/MacExamples.scala
@@ -1,5 +1,3 @@
-
-
 object MacExamples {
 
   /** Example message authentication: Note, will use byteutils */
@@ -16,10 +14,11 @@ object MacExamples {
   } yield verified
 
   import cats.effect.IO
+
   /** For Interpetation into IO */
-  val macPureInstance: JCAMacPure[HMACSHA256] = JCAMacPure[HMACSHA256]
+  val macPureInstance: JCAMacPure[IO, HMACSHA256] = JCAMacPure[IO, HMACSHA256]
   val `mac'd-pure`: IO[Boolean] = for {
-    key       <- HMACSHA256.generateLift[IO]                     //Generate our key.
+    key       <- HMACSHA256.generateLift[IO]                        //Generate our key.
     macValue  <- macPureInstance.sign(toMac, key)                   //Generate our MAC bytes
     verified  <- macPureInstance.verify(toMac, macValue, key)       //Verify a byte array with a signed, typed instance
     verified2 <- macPureInstance.verifyArrays(toMac, macValue, key) //Alternatively, use arrays directly

--- a/jwt-core/src/main/scala/tsec/jwt/JWTClaims.scala
+++ b/jwt-core/src/main/scala/tsec/jwt/JWTClaims.scala
@@ -9,6 +9,7 @@ import io.circe._
 import io.circe.generic.auto._
 import io.circe.parser.decode
 import io.circe.syntax._
+import tsec.common.SecureRandomId
 import tsec.jws.JWSSerializer
 
 import scala.concurrent.duration.FiniteDuration
@@ -20,7 +21,7 @@ case class JWTClaims(
     expiration: Option[Long] = None,
     notBefore: Option[Long] = None,
     issuedAt: Option[Long] = Some(Instant.now().getEpochSecond), // IEEE Std 1003.1, 2013 Edition time in seconds
-    jwtId: UUID = UUID.randomUUID(), //Case sensitive, and in our implementation, secure enough using UUIDv4
+    jwtId: String = SecureRandomId.generate, //Case sensitive, and in our implementation, secure enough using UUIDv4
     custom: Option[Json] = None // non standard. I copped out. Other things are most likely too inefficient to use
 ) {
   def withExpiry(duration: FiniteDuration): JWTClaims =
@@ -44,7 +45,7 @@ object JWTClaims extends JWSSerializer[JWTClaims] {
       audience: Option[Either[String, List[String]]] = None, //case-sensitive
       expiration: Option[FiniteDuration],
       notBefore: Option[FiniteDuration] = None,
-      jwtId: UUID = UUID.randomUUID(), //Case sensitive
+      jwtId: String = SecureRandomId.generate, //Case sensitive
       custom: Option[Json] = None
   ): JWTClaims = {
     val now = Instant.now().getEpochSecond
@@ -91,7 +92,7 @@ object JWTClaims extends JWSSerializer[JWTClaims] {
         expiration <- c.downField("exp").as[Option[Long]]
         nbf        <- c.downField("nbf").as[Option[Long]]
         iat        <- c.downField("iat").as[Option[Long]]
-        jwtid      <- c.downField("jti").as[UUID]
+        jwtid      <- c.downField("jti").as[String]
         custom = c.downField("custom").focus
       } yield JWTClaims(iss, sub, aud, expiration, nbf, iat, jwtid, custom)
   }

--- a/jwt-mac/src/main/scala/tsec/jws/mac/JWSMacCV.scala
+++ b/jwt-mac/src/main/scala/tsec/jws/mac/JWSMacCV.scala
@@ -104,7 +104,7 @@ object JWSMacCV {
 
   implicit def genSignerIO[A: ByteEV](
       implicit hs: JWSSerializer[JWSMacHeader[A]],
-      alg: JCAMacPure[A]
+      alg: JCAMacPure[IO, A]
   ): JWSMacCV[IO, A] =
     new JWSMacCV[IO, A]() {}
 

--- a/mac/src/main/scala/tsec/mac/imports/JCAMacPure.scala
+++ b/mac/src/main/scala/tsec/mac/imports/JCAMacPure.scala
@@ -1,16 +1,16 @@
 package tsec.mac.imports
 
-import cats.effect.IO
+import cats.effect.{IO, Sync}
 import tsec.common.ByteEV
 import tsec.mac.core.MacPrograms
 
-class JCAMacPure[A: ByteEV: MacTag](algebra: JMacPureInterpreter[A])
-    extends MacPrograms[IO, A, MacSigningKey](algebra) {}
+class JCAMacPure[F[_]: Sync, A: ByteEV: MacTag](algebra: JMacPureInterpreter[F, A])
+    extends MacPrograms[F, A, MacSigningKey](algebra) {}
 
 object JCAMacPure {
-  def apply[A: ByteEV: MacTag](implicit alg: JMacPureInterpreter[A]) =
-    new JCAMacPure[A](alg)
+  def apply[F[_]: Sync, A: ByteEV: MacTag](implicit alg: JMacPureInterpreter[F, A]) =
+    new JCAMacPure[F, A](alg)
 
-  implicit def generate[A: ByteEV: MacTag](implicit alg: JMacPureInterpreter[A]): JCAMacPure[A] =
-    apply[A]
+  implicit def generate[F[_]: Sync, A: ByteEV: MacTag](implicit alg: JMacPureInterpreter[F, A]): JCAMacPure[F, A] =
+    apply[F, A]
 }

--- a/mac/src/main/scala/tsec/mac/imports/JMacPureInterpreter.scala
+++ b/mac/src/main/scala/tsec/mac/imports/JMacPureInterpreter.scala
@@ -2,26 +2,46 @@ package tsec.mac.imports
 
 import javax.crypto.Mac
 
-import cats.effect.IO
+import cats.effect.Sync
+import cats.syntax.all._
 import tsec.common.ByteEV
+import java.util.concurrent.{ConcurrentLinkedQueue => JQueue}
 import tsec.mac.core.MacAlgebra
 
-sealed protected[tsec] abstract class JMacPureInterpreter[A: ByteEV](implicit macTag: MacTag[A])
-    extends MacAlgebra[IO, A, MacSigningKey] {
+sealed protected[tsec] abstract class JMacPureInterpreter[F[_], A: ByteEV](tl: JQueue[Mac])(
+    implicit F: Sync[F],
+    macTag: MacTag[A]
+) extends MacAlgebra[F, A, MacSigningKey] {
   type M = Mac
 
-  def genInstance: IO[Mac] = IO(Mac.getInstance(macTag.algorithm))
+  def genInstance: F[Mac] =
+    F.delay {
+      val inst = tl.poll()
+      if (inst != null)
+        inst
+      else
+        Mac.getInstance(macTag.algorithm)
+    }
 
-  def sign(content: Array[Byte], key: MacSigningKey[A]): IO[Array[Byte]] =
+  def sign(content: Array[Byte], key: MacSigningKey[A]): F[Array[Byte]] =
     for {
       instance <- genInstance
-      _        <- IO(instance.init(MacSigningKey.toJavaKey[A](key)))
-      result   <- IO(instance.doFinal(content))
-    } yield result
+      _        <- F.delay(instance.init(MacSigningKey.toJavaKey[A](key)))
+      fin      <- F.delay(instance.doFinal(content))
+      _        <- F.delay(tl.add(instance))
+    } yield fin
 }
 
 object JMacPureInterpreter {
-  def apply[A: ByteEV: MacTag] = new JMacPureInterpreter[A] {}
+  def apply[F[_]: Sync, A: ByteEV](numInstances: Int = 10)(implicit tag: MacTag[A]) = {
+    val queue = new JQueue[Mac]()
+    var i     = 0
+    while (i < numInstances) {
+      queue.add(Mac.getInstance(tag.algorithm))
+      i += 1
+    }
+    new JMacPureInterpreter[F, A](queue) {}
+  }
 
-  implicit def gen[A: ByteEV: MacTag]: JMacPureInterpreter[A] = apply[A]
+  implicit def gen[F[_]: Sync, A: ByteEV: MacTag]: JMacPureInterpreter[F, A] = apply[F, A]()
 }

--- a/mac/src/main/scala/tsec/mac/imports/MacTag.scala
+++ b/mac/src/main/scala/tsec/mac/imports/MacTag.scala
@@ -3,3 +3,7 @@ package tsec.mac.imports
 import tsec.common.CryptoTag
 
 protected[tsec] trait MacTag[T] extends CryptoTag[T]
+
+object MacTag {
+  @inline def apply[T](implicit M: MacTag[T]): MacTag[T] = M
+}

--- a/mac/src/main/scala/tsec/mac/imports/threadlocal/JMacPureI.scala
+++ b/mac/src/main/scala/tsec/mac/imports/threadlocal/JMacPureI.scala
@@ -3,6 +3,7 @@ package tsec.mac.imports.threadlocal
 import javax.crypto.Mac
 import cats.effect.IO
 import tsec.common.QueueAlloc
+import java.util.concurrent.{ConcurrentLinkedQueue => JQueue}
 import tsec.mac.core.MacAlgebra
 import tsec.mac.imports.{MacSigningKey, MacTag}
 

--- a/mac/src/test/scala/tsec/MacTests.scala
+++ b/mac/src/test/scala/tsec/MacTests.scala
@@ -1,12 +1,12 @@
 package tsec
 
+import cats.effect.IO
 import org.scalatest.MustMatchers
 import tsec.common._
 import tsec.common.JKeyGenerator
 import tsec.mac.imports.{MacSigningKey, _}
 
 class MacTests extends TestSpec with MustMatchers {
-
 
   def macTest[T: ByteEV](implicit keyGen: JKeyGenerator[T, MacSigningKey, MacKeyBuildError], tag: MacTag[T]): Unit = {
     behavior of tag.algorithm
@@ -17,8 +17,8 @@ class MacTests extends TestSpec with MustMatchers {
       val dataToSign = "awwwwwwwwwwwwwwwwwwwwwww YEAH".utf8Bytes
 
       val res: Either[Throwable, Boolean] = for {
-        k <- keyGen.generateKey()
-        signed <- instance.sign(dataToSign, k)
+        k        <- keyGen.generateKey()
+        signed   <- instance.sign(dataToSign, k)
         verified <- instance.verify(dataToSign, signed, k)
       } yield verified
 
@@ -29,7 +29,7 @@ class MacTests extends TestSpec with MustMatchers {
       val dataToSign = "awwwwwwwwwwwwwwwwwwwwwww YEAH".utf8Bytes
 
       val res: Either[Throwable, Boolean] = for {
-        k <- keyGen.generateKey()
+        k       <- keyGen.generateKey()
         signed1 <- instance.algebra.sign(dataToSign, k)
         signed2 <- instance.algebra.sign(dataToSign, k)
       } yield ByteUtils.constantTimeEquals(signed1, signed2)
@@ -38,12 +38,12 @@ class MacTests extends TestSpec with MustMatchers {
 
     it should "not verify for different messages" in {
       val dataToSign = "awwwwwwwwwwwwwwwwwwwwwww YEAH".utf8Bytes
-      val incorrect = "hello my kekistanis".utf8Bytes
+      val incorrect  = "hello my kekistanis".utf8Bytes
 
       val res: Either[Throwable, Boolean] = for {
-        k <- keyGen.generateKey()
+        k       <- keyGen.generateKey()
         signed1 <- instance.sign(dataToSign, k)
-        cond <- instance.verify(incorrect,signed1, k)
+        cond    <- instance.verify(incorrect, signed1, k)
       } yield cond
 
       res mustBe Right(false)
@@ -54,13 +54,71 @@ class MacTests extends TestSpec with MustMatchers {
       val dataToSign = "awwwwwwwwwwwwwwwwwwwwwww YEAH".utf8Bytes
 
       val res: Either[Throwable, Boolean] = for {
-        k <- keyGen.generateKey()
-        k2 <- keyGen.generateKey()
+        k       <- keyGen.generateKey()
+        k2      <- keyGen.generateKey()
         signed1 <- instance.sign(dataToSign, k)
-        cond <- instance.verify(dataToSign,signed1, k2)
+        cond    <- instance.verify(dataToSign, signed1, k2)
       } yield cond
 
       res mustBe Right(false)
+
+    }
+
+    /*
+    Pure tests
+     */
+    val pureinstance = JCAMacPure[IO, T]
+
+    behavior of (tag.algorithm + " pure interpreter")
+
+    it should "Sign then verify the same encrypted data properly" in {
+      val dataToSign = "awwwwwwwwwwwwwwwwwwwwwww YEAH".utf8Bytes
+
+      val res = for {
+        k        <- keyGen.generateLift[IO]
+        signed   <- pureinstance.sign(dataToSign, k)
+        verified <- pureinstance.verify(dataToSign, signed, k)
+      } yield verified
+
+      res.unsafeRunSync() mustBe true
+    }
+
+    it should "sign to the same message" in {
+      val dataToSign = "awwwwwwwwwwwwwwwwwwwwwww YEAH".utf8Bytes
+
+      val res: IO[Boolean] = for {
+        k       <- keyGen.generateLift[IO]
+        signed1 <- pureinstance.algebra.sign(dataToSign, k)
+        signed2 <- pureinstance.algebra.sign(dataToSign, k)
+      } yield ByteUtils.constantTimeEquals(signed1, signed2)
+      res.unsafeRunSync() mustBe true
+    }
+
+    it should "not verify for different messages" in {
+      val dataToSign = "awwwwwwwwwwwwwwwwwwwwwww YEAH".utf8Bytes
+      val incorrect  = "hello my kekistanis".utf8Bytes
+
+      val res = for {
+        k       <- keyGen.generateLift[IO]
+        signed1 <- pureinstance.sign(dataToSign, k)
+        cond    <- pureinstance.verify(incorrect, signed1, k)
+      } yield cond
+
+      res.unsafeRunSync() mustBe false
+    }
+
+    it should "not verify for different keys" in {
+
+      val dataToSign = "awwwwwwwwwwwwwwwwwwwwwww YEAH".utf8Bytes
+
+      val res = for {
+        k       <- keyGen.generateLift[IO]
+        k2      <- keyGen.generateLift[IO]
+        signed1 <- pureinstance.sign(dataToSign, k)
+        cond    <- pureinstance.verify(dataToSign, signed1, k2)
+      } yield cond
+
+      res.unsafeRunSync() mustBe false
 
     }
   }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -14,6 +14,7 @@ object Dependencies {
     val scalaTestV    = "3.0.4"
     val http4sV       = "0.18.0-M5"
     val scalacheckV   = "1.13.4"
+    val commonsCodecV = "1.11"
   }
 
   object Libraries {
@@ -32,6 +33,7 @@ object Dependencies {
     val http4sServer       = "org.http4s"         %% "http4s-server"        % Versions.http4sV
     val http4sCirce        = "org.http4s"         %% "http4s-circe"         % Versions.http4sV % "test"
     val scalaCheck         = "org.scalacheck"     %% "scalacheck"           % Versions.scalacheckV % "test"
+    val commonsCodec       = "commons-codec"      % "commons-codec"         % Versions.commonsCodecV
   }
 
 }

--- a/tsec-http4s/src/main/scala/tsec/authentication/Authenticator.scala
+++ b/tsec-http4s/src/main/scala/tsec/authentication/Authenticator.scala
@@ -8,51 +8,50 @@ import org.http4s.{Request, Response}
 
 /** A base typeclass for generating authenticators, i.e cookies, tokens, JWTs etc.
   *
-  * @tparam Alg The related cryptographic algorithm used in authentication
   * @tparam I The Identifier type
   * @tparam V The value type, i.e user, or possibly only partial information
   */
-trait Authenticator[F[_], Alg, I, V, Authenticator[_]] {
+trait Authenticator[F[_], I, V, Authenticator] {
 
   /** Return a secured request from a request, that carries our authenticator
     * @param request
     * @return
     */
-  def extractAndValidate(request: Request[F]): OptionT[F, SecuredRequest[F, Authenticator[Alg], V]]
+  def extractAndValidate(request: Request[F]): OptionT[F, SecuredRequest[F, Authenticator, V]]
 
   /** Create an authenticator from an identifier.
     * @param body
     * @return
     */
-  def create(body: I): OptionT[F, Authenticator[Alg]]
+  def create(body: I): OptionT[F, Authenticator]
 
   /** Update the altered authenticator
     *
     * @param authenticator
     * @return
     */
-  def update(authenticator: Authenticator[Alg]): OptionT[F, Authenticator[Alg]]
+  def update(authenticator: Authenticator): OptionT[F, Authenticator]
 
   /** Delete an authenticator from a backing store, or invalidate it.
     *
     * @param authenticator
     * @return
     */
-  def discard(authenticator: Authenticator[Alg]): OptionT[F, Authenticator[Alg]]
+  def discard(authenticator: Authenticator): OptionT[F, Authenticator]
 
   /** Renew an authenticator: Reset it's expiry and whatnot.
     *
     * @param authenticator
     * @return
     */
-  def renew(authenticator: Authenticator[Alg]): OptionT[F, Authenticator[Alg]]
+  def renew(authenticator: Authenticator): OptionT[F, Authenticator]
 
   /** Refresh an authenticator: Primarily used for sliding window expiration
     *
     * @param authenticator
     * @return
     */
-  def refresh(authenticator: Authenticator[Alg]): OptionT[F, Authenticator[Alg]]
+  def refresh(authenticator: Authenticator): OptionT[F, Authenticator]
 
   /** Embed an authenticator directly into a response.
     * Particularly useful for adding an authenticator into unauthenticated actions
@@ -60,7 +59,7 @@ trait Authenticator[F[_], Alg, I, V, Authenticator[_]] {
     * @param response
     * @return
     */
-  def embed(response: Response[F], authenticator: Authenticator[Alg]): Response[F]
+  def embed(response: Response[F], authenticator: Authenticator): Response[F]
 
   /** Handles the embedding of the authenticator (if necessary) in the response,
     * and any other actions that should happen after a request related to authenticators
@@ -69,6 +68,6 @@ trait Authenticator[F[_], Alg, I, V, Authenticator[_]] {
     * @param authenticator
     * @return
     */
-  def afterBlock(response: Response[F], authenticator: Authenticator[Alg]): OptionT[F, Response[F]]
+  def afterBlock(response: Response[F], authenticator: Authenticator): OptionT[F, Response[F]]
 
 }

--- a/tsec-http4s/src/main/scala/tsec/authentication/BearerTokenAuthenticator.scala
+++ b/tsec-http4s/src/main/scala/tsec/authentication/BearerTokenAuthenticator.scala
@@ -1,0 +1,128 @@
+package tsec.authentication
+
+import java.time.Instant
+
+import cats.MonadError
+import cats.data.OptionT
+import org.http4s.headers.Authorization
+import org.http4s.util.CaseInsensitiveString
+import org.http4s.{AuthScheme, Credentials, Request, Response}
+import tsec.cipher.symmetric._
+import tsec.cipher.symmetric.imports._
+import tsec.common._
+import tsec.messagedigests._
+import tsec.messagedigests.imports._
+import cats.syntax.all._
+
+import scala.concurrent.duration._
+
+sealed abstract class BearerTokenAuthenticator[F[_], I, V] extends Authenticator[F, I, V, TSecBearerToken[I]] {
+
+  def withIdentityStore(newStore: BackingStore[F, I, V]): BearerTokenAuthenticator[F, I, V]
+
+  def withTokenStore(
+      newStore: BackingStore[F, SecureRandomId, TSecBearerToken[I]]
+  ): BearerTokenAuthenticator[F, I, V]
+}
+
+final case class TSecBearerToken[I](
+    id: SecureRandomId,
+    messageId: I,
+    expiry: Instant,
+    lastTouched: Option[Instant]
+) {
+  def isExpired(now: Instant): Boolean = expiry.isBefore(now)
+  def isTimedout(now: Instant, timeOut: FiniteDuration): Boolean =
+    lastTouched.exists(
+      _.plusSeconds(timeOut.toSeconds)
+        .isBefore(now)
+    )
+}
+
+object BearerTokenAuthenticator {
+  def apply[F[_], I, V](
+      tokenStore: BackingStore[F, SecureRandomId, TSecBearerToken[I]],
+      identityStore: BackingStore[F, I, V],
+      settings: TSecTokenSettings,
+  )(implicit M: MonadError[F, Throwable]): BearerTokenAuthenticator[F, I, V] =
+    new BearerTokenAuthenticator[F, I, V] {
+
+      def withIdentityStore(newStore: BackingStore[F, I, V]): BearerTokenAuthenticator[F, I, V] =
+        apply(tokenStore, newStore, settings)
+
+      def withTokenStore(
+          newStore: BackingStore[F, SecureRandomId, TSecBearerToken[I]]
+      ): BearerTokenAuthenticator[F, I, V] =
+        apply(newStore, identityStore, settings)
+
+      private def validate(token: TSecBearerToken[I]) = {
+        val now = Instant.now()
+        !token.isExpired(now) && settings.maxIdle.forall(token.isTimedout(now, _))
+      }
+
+      def extractAndValidate(request: Request[F]): OptionT[F, SecuredRequest[F, TSecBearerToken[I], V]] =
+        for {
+          rawToken  <- OptionT.fromOption[F](extractBearerToken[F](request))
+          token     <- tokenStore.get(SecureRandomId.coerce(rawToken))
+          _         <- if (validate(token)) OptionT.pure(()) else OptionT.none
+          refreshed <- refresh(token)
+          identity  <- identityStore.get(token.messageId)
+        } yield SecuredRequest(request, refreshed, identity)
+
+      def create(body: I): OptionT[F, TSecBearerToken[I]] = {
+        val newID = SecureRandomId.generate
+        val now   = Instant.now()
+        val newToken = TSecBearerToken(
+          newID,
+          body,
+          now.plusSeconds(settings.expirationTime.toSeconds),
+          settings.maxIdle.map(_ => now)
+        )
+
+        OptionT.liftF(tokenStore.put(newToken)).mapFilter {
+          case 1 => Some(newToken)
+          case _ => None
+        }
+      }
+
+      def update(authenticator: TSecBearerToken[I]): OptionT[F, TSecBearerToken[I]] =
+        OptionT.liftF(tokenStore.update(authenticator)).mapFilter {
+          case 1 => Some(authenticator)
+          case _ => None
+        }
+
+      def discard(authenticator: TSecBearerToken[I]): OptionT[F, TSecBearerToken[I]] =
+        OptionT.liftF(tokenStore.delete(authenticator.id)).mapFilter {
+          case 1 => Some(authenticator)
+          case _ => None
+        }
+
+      def renew(authenticator: TSecBearerToken[I]): OptionT[F, TSecBearerToken[I]] = {
+        val now = Instant.now()
+        val newToken = authenticator.copy(
+          expiry = now.plusSeconds(settings.expirationTime.toSeconds),
+          lastTouched = settings.maxIdle.map(_ => now)
+        )
+        update(newToken)
+      }
+
+      def refresh(authenticator: TSecBearerToken[I]): OptionT[F, TSecBearerToken[I]] = settings.maxIdle match {
+        case None =>
+          OptionT.pure(authenticator)
+        case Some(idleTime) =>
+          val now = Instant.now()
+          update(authenticator.copy(lastTouched = Some(now.plusSeconds(idleTime.toSeconds))))
+      }
+
+      def embed(response: Response[F], authenticator: TSecBearerToken[I]): Response[F] =
+        response.putHeaders(Authorization(Credentials.Token(AuthScheme.Bearer, authenticator.id)))
+
+      def afterBlock(response: Response[F], authenticator: TSecBearerToken[I]): OptionT[F, Response[F]] =
+        settings.maxIdle match {
+          case Some(_) =>
+            OptionT.pure[F](embed(response, authenticator))
+          case None =>
+            OptionT.pure[F](response)
+        }
+    }
+}

--- a/tsec-http4s/src/main/scala/tsec/authentication/BearerTokenAuthenticator.scala
+++ b/tsec-http4s/src/main/scala/tsec/authentication/BearerTokenAuthenticator.scala
@@ -78,25 +78,14 @@ object BearerTokenAuthenticator {
           now.plusSeconds(settings.expirationTime.toSeconds),
           settings.maxIdle.map(_ => now)
         )
-        OptionT.liftF(tokenStore.put(newToken)).mapFilter {
-          case 1 =>
-            Some(newToken)
-          case _ =>
-            None
-        }
+        OptionT.liftF(tokenStore.put(newToken))
       }
 
       def update(authenticator: TSecBearerToken[I]): OptionT[F, TSecBearerToken[I]] =
-        OptionT.liftF(tokenStore.update(authenticator)).mapFilter {
-          case 1 => Some(authenticator)
-          case _ => None
-        }
+        OptionT.liftF(tokenStore.update(authenticator))
 
       def discard(authenticator: TSecBearerToken[I]): OptionT[F, TSecBearerToken[I]] =
-        OptionT.liftF(tokenStore.delete(authenticator.id)).mapFilter {
-          case 1 => Some(authenticator)
-          case _ => None
-        }
+        OptionT.liftF(tokenStore.delete(authenticator.id)).map(_ => authenticator)
 
       def renew(authenticator: TSecBearerToken[I]): OptionT[F, TSecBearerToken[I]] = {
         val now = Instant.now()

--- a/tsec-http4s/src/main/scala/tsec/authentication/CookieAuthenticator.scala
+++ b/tsec-http4s/src/main/scala/tsec/authentication/CookieAuthenticator.scala
@@ -194,16 +194,10 @@ object CookieAuthenticator {
       }
 
       def update(authenticator: AuthenticatedCookie[Alg, I]): OptionT[F, AuthenticatedCookie[Alg, I]] =
-        OptionT.liftF(tokenStore.update(authenticator)).mapFilter {
-          case 1 => Some(authenticator)
-          case _ => None
-        }
+        OptionT.liftF(tokenStore.update(authenticator))
 
       def discard(authenticator: AuthenticatedCookie[Alg, I]): OptionT[F, AuthenticatedCookie[Alg, I]] =
-        OptionT.liftF(tokenStore.delete(authenticator.id)).mapFilter {
-          case 1 => Some(authenticator)
-          case _ => None
-        }
+        OptionT.liftF(tokenStore.delete(authenticator.id)).map(_ => authenticator)
 
       /** Renew an authenticator: Reset it's expiry and whatnot.
         *

--- a/tsec-http4s/src/main/scala/tsec/authentication/CookieAuthenticator.scala
+++ b/tsec-http4s/src/main/scala/tsec/authentication/CookieAuthenticator.scala
@@ -17,7 +17,7 @@ import cats.syntax.eq._
 import scala.concurrent.duration.FiniteDuration
 
 abstract class CookieAuthenticator[F[_], Alg: MacTag: ByteEV, I, V]
-    extends Authenticator[F, Alg, I, V, AuthenticatedCookie[?, I]]
+    extends Authenticator[F, I, V, AuthenticatedCookie[Alg, I]]
 
 /** An authenticated cookie implementation
   *

--- a/tsec-http4s/src/main/scala/tsec/authentication/EncryptedCookieAuthenticator.scala
+++ b/tsec-http4s/src/main/scala/tsec/authentication/EncryptedCookieAuthenticator.scala
@@ -267,19 +267,13 @@ object EncryptedCookieAuthenticator {
         *
         */
       def update(authenticator: AuthEncryptedCookie[Alg, I]): OptionT[F, AuthEncryptedCookie[Alg, I]] =
-        OptionT.liftF(tokenStore.update(authenticator)).mapFilter {
-          case 1 => Some(authenticator)
-          case _ => None
-        }
+        OptionT.liftF(tokenStore.update(authenticator))
 
       /** Discard our authenticator from the backing store
         *
         */
       def discard(authenticator: AuthEncryptedCookie[Alg, I]): OptionT[F, AuthEncryptedCookie[Alg, I]] =
-        OptionT.liftF(tokenStore.delete(authenticator.id)).mapFilter {
-          case 1 => Some(authenticator)
-          case _ => None
-        }
+        OptionT.liftF(tokenStore.delete(authenticator.id)).map(_ => authenticator)
 
       /** Renew, aka reset both the expiry as well as the last touched (if present) value
         *

--- a/tsec-http4s/src/main/scala/tsec/authentication/EncryptedCookieAuthenticator.scala
+++ b/tsec-http4s/src/main/scala/tsec/authentication/EncryptedCookieAuthenticator.scala
@@ -22,7 +22,7 @@ import cats.implicits._
 import tsec.jwt.JWTPrinter
 
 sealed abstract class EncryptedCookieAuthenticator[F[_], A, I, V](implicit auth: AuthEncryptor[A])
-    extends Authenticator[F, A, I, V, AuthEncryptedCookie[?, I]]
+    extends Authenticator[F, I, V, AuthEncryptedCookie[A, I]]
 
 sealed abstract class StatefulECAuthenticator[F[_], A, I, V](implicit auth: AuthEncryptor[A])
     extends EncryptedCookieAuthenticator[F, A, I, V] {

--- a/tsec-http4s/src/main/scala/tsec/authentication/JWTAuthenticator.scala
+++ b/tsec-http4s/src/main/scala/tsec/authentication/JWTAuthenticator.scala
@@ -21,7 +21,7 @@ import cats.implicits._
 import scala.concurrent.duration.FiniteDuration
 
 sealed abstract class JWTAuthenticator[F[_], A, I, V](implicit jWSMacCV: JWSMacCV[F, A])
-    extends Authenticator[F, A, I, V, JWTMac]
+    extends Authenticator[F, I, V, JWTMac[A]]
 
 sealed abstract class StatefulJWTAuthenticator[F[_], A, I, V](implicit jWSMacCV: JWSMacCV[F, A])
     extends JWTAuthenticator[F, A, I, V] {

--- a/tsec-http4s/src/main/scala/tsec/authentication/JWTAuthenticator.scala
+++ b/tsec-http4s/src/main/scala/tsec/authentication/JWTAuthenticator.scala
@@ -204,20 +204,10 @@ object JWTAuthenticator {
       }
 
       def update(authenticator: JWTMac[A]): OptionT[F, JWTMac[A]] =
-        for {
-          auth <- OptionT.liftF(tokenStore.update(authenticator)).mapFilter {
-            case 1 => Some(authenticator)
-            case _ => None
-          }
-        } yield auth
+        OptionT.liftF(tokenStore.update(authenticator))
 
       def discard(authenticator: JWTMac[A]): OptionT[F, JWTMac[A]] =
-        for {
-          auth <- OptionT.liftF(tokenStore.delete(SecureRandomId.coerce(authenticator.id))).mapFilter {
-            case 1 => Some(authenticator)
-            case _ => None
-          }
-        } yield auth
+          OptionT.liftF(tokenStore.delete(SecureRandomId.coerce(authenticator.id))).map(_ => authenticator)
 
       def renew(authenticator: JWTMac[A]): OptionT[F, JWTMac[A]] = {
         val now           = Instant.now()

--- a/tsec-http4s/src/main/scala/tsec/authentication/SecuredRequestHandler.scala
+++ b/tsec-http4s/src/main/scala/tsec/authentication/SecuredRequestHandler.scala
@@ -1,10 +1,9 @@
 package tsec.authentication
 
-import cats.{Monad, MonadError}
-import cats.data.{Kleisli, OptionT}
+import cats.MonadError
+import cats.data.Kleisli
 import org.http4s._
 import cats.syntax.all._
-import tsec.jws.mac.JWTMac
 import tsec.authorization._
 
 sealed abstract class SecuredRequestHandler[F[_], Identity, User, Auth](

--- a/tsec-http4s/src/main/scala/tsec/authentication/SecuredRequestHandler.scala
+++ b/tsec-http4s/src/main/scala/tsec/authentication/SecuredRequestHandler.scala
@@ -7,85 +7,54 @@ import cats.syntax.all._
 import tsec.jws.mac.JWTMac
 import tsec.authorization._
 
-sealed abstract class SecuredRequestHandler[F[_], Alg, Identity, User, Auth[_]](
-    val authenticator: Authenticator[F, Alg, Identity, User, Auth]
+sealed abstract class SecuredRequestHandler[F[_], Identity, User, Auth](
+    val authenticator: Authenticator[F, Identity, User, Auth]
 )(implicit F: MonadError[F, Throwable]) {
 
-  protected def authorizedMiddleware(authorization: Authorization[F, User]): TSecMiddleware[F, Auth[Alg], User] = {
+  protected def authorizedMiddleware(authorization: Authorization[F, User]): TSecMiddleware[F, Auth, User] = {
     val authed = Kleisli(authenticator.extractAndValidate)
       .andThen(e => authorization.isAuthorized(e))
     TSecMiddleware(authed)
   }
 
-  def apply(pf: PartialFunction[SecuredRequest[F, Auth[Alg], User], F[Response[F]]]): HttpService[F]
+  def apply(pf: PartialFunction[SecuredRequest[F, Auth, User], F[Response[F]]]): HttpService[F]
 
   def authorized(authorization: Authorization[F, User])(
-      pf: PartialFunction[SecuredRequest[F, Auth[Alg], User], F[Response[F]]]
+      pf: PartialFunction[SecuredRequest[F, Auth, User], F[Response[F]]]
   ): HttpService[F]
 
 }
 
 object SecuredRequestHandler {
 
-  def apply[F[_], Alg, Identity, User, Auth[_]](
-      authenticator: Authenticator[F, Alg, Identity, User, Auth],
+  def apply[F[_], Identity, User, Auth](
+      authenticator: Authenticator[F, Identity, User, Auth],
       rolling: Boolean = false
-  )(implicit F: MonadError[F, Throwable]): SecuredRequestHandler[F, Alg, Identity, User, Auth] = {
+  )(implicit F: MonadError[F, Throwable]): SecuredRequestHandler[F, Identity, User, Auth] = {
     val middleware = TSecMiddleware(Kleisli(authenticator.extractAndValidate))
     if (rolling) {
-      new SecuredRequestHandler[F, Alg, Identity, User, Auth](authenticator) {
-        def apply(pf: PartialFunction[SecuredRequest[F, Auth[Alg], User], F[Response[F]]]): HttpService[F] =
+      new SecuredRequestHandler[F, Identity, User, Auth](authenticator) {
+        def apply(pf: PartialFunction[SecuredRequest[F, Auth, User], F[Response[F]]]): HttpService[F] =
           middleware(TSecAuthService(pf))
             .handleError(_ => Response[F](Status.Forbidden))
 
         def authorized(authorization: Authorization[F, User])(
-            pf: PartialFunction[SecuredRequest[F, Auth[Alg], User], F[Response[F]]]
+            pf: PartialFunction[SecuredRequest[F, Auth, User], F[Response[F]]]
         ): HttpService[F] =
           authorizedMiddleware(authorization)(TSecAuthService(pf))
             .handleError(_ => Response[F](Status.Forbidden))
       }
     } else
-      new SecuredRequestHandler[F, Alg, Identity, User, Auth](authenticator) {
-        def apply(pf: PartialFunction[SecuredRequest[F, Auth[Alg], User], F[Response[F]]]): HttpService[F] =
+      new SecuredRequestHandler[F, Identity, User, Auth](authenticator) {
+        def apply(pf: PartialFunction[SecuredRequest[F, Auth, User], F[Response[F]]]): HttpService[F] =
           middleware(TSecAuthService(pf, authenticator.afterBlock))
             .handleError(_ => Response[F](Status.Forbidden))
 
         def authorized(
             authorization: Authorization[F, User]
-        )(pf: PartialFunction[SecuredRequest[F, Auth[Alg], User], F[Response[F]]]): HttpService[F] =
+        )(pf: PartialFunction[SecuredRequest[F, Auth, User], F[Response[F]]]): HttpService[F] =
           authorizedMiddleware(authorization)(TSecAuthService(pf, authenticator.afterBlock))
             .handleError(_ => Response[F](Status.Forbidden))
       }
   }
-
-  private[authentication] final class DefaultEncrypted[F[_]](val dummy: Boolean = true) extends AnyVal {
-    def apply[Alg, Identity, User](
-        authenticator: Authenticator[F, Alg, Identity, User, AuthEncryptedCookie[?, Identity]],
-        rolling: Boolean = false
-    )(implicit F: MonadError[F, Throwable]) =
-      SecuredRequestHandler[F, Alg, Identity, User, AuthEncryptedCookie[?, Identity]](authenticator, rolling)
-  }
-
-  private[authentication] final class DefaultCookie[F[_]](val dummy: Boolean = true) extends AnyVal {
-    def apply[Alg, Identity, User](
-        authenticator: Authenticator[F, Alg, Identity, User, AuthenticatedCookie[?, Identity]],
-        rolling: Boolean = false
-    )(implicit F: MonadError[F, Throwable]) =
-      SecuredRequestHandler[F, Alg, Identity, User, AuthenticatedCookie[?, Identity]](authenticator, rolling)
-  }
-
-  private[authentication] final class DefaultJWT[F[_]](val dummy: Boolean = true) extends AnyVal {
-    def apply[Alg, Identity, User](
-        authenticator: Authenticator[F, Alg, Identity, User, JWTMac],
-        rolling: Boolean = false
-    )(implicit F: MonadError[F, Throwable]) =
-      SecuredRequestHandler[F, Alg, Identity, User, JWTMac](authenticator, rolling)
-  }
-
-  final def encryptedCookie[F[_]]: DefaultEncrypted[F] = new DefaultEncrypted[F]()
-
-  final def signedCookie[F[_]]: DefaultCookie[F] = new DefaultCookie[F]()
-
-  final def jwt[F[_]]: DefaultJWT[F] = new DefaultJWT[F]()
-
 }

--- a/tsec-http4s/src/main/scala/tsec/authentication/credentials/CredentialStore.scala
+++ b/tsec-http4s/src/main/scala/tsec/authentication/credentials/CredentialStore.scala
@@ -1,0 +1,34 @@
+package tsec.authentication.credentials
+
+import cats.effect.Sync
+import cats.syntax.all._
+import tsec.passwordhashers._
+import tsec.passwordhashers.core.{PWHashPrograms, PasswordValidated}
+import tsec.passwordhashers.imports._
+
+/** An trait representing the common operations you would do to/with credentials, such as
+  * logging in with a password, or validating an oauth token to log in
+  *
+  */
+trait CredentialStore[F[_], C, P] {
+
+  def putCredentials(credentials: C): F[Unit]
+
+  def updateCredentials(credentials: C): F[Unit]
+
+  def removeCredentials(credentials: C): F[Unit]
+
+  def authenticate(credentials: C): F[Boolean]
+}
+
+abstract class PasswordStore[F[_]: Sync, Id, P](implicit h: PWHashPrograms[PasswordValidated, P]) extends CredentialStore[F, RawCredentials[Id], P] {
+
+  def retrievePass(id: Id): F[P]
+
+  def authenticate(credentials: RawCredentials[Id]): F[Boolean] =
+    retrievePass(credentials.identity).map(credentials.rawPassword.checkWithHash[P])
+}
+
+trait SCryptPasswordStore[F[_], Id] extends PasswordStore[F, Id, SCrypt]
+
+trait BCryptPasswordStore[F[_], Id] extends PasswordStore[F, Id, BCrypt]

--- a/tsec-http4s/src/main/scala/tsec/authentication/credentials/CredentialStore.scala
+++ b/tsec-http4s/src/main/scala/tsec/authentication/credentials/CredentialStore.scala
@@ -21,7 +21,8 @@ trait CredentialStore[F[_], C, P] {
   def authenticate(credentials: C): F[Boolean]
 }
 
-abstract class PasswordStore[F[_]: Sync, Id, P](implicit h: PWHashPrograms[PasswordValidated, P]) extends CredentialStore[F, RawCredentials[Id], P] {
+abstract class PasswordStore[F[_]: Sync, Id, P](implicit h: PWHashPrograms[PasswordValidated, P])
+    extends CredentialStore[F, RawCredentials[Id], P] {
 
   def retrievePass(id: Id): F[P]
 

--- a/tsec-http4s/src/main/scala/tsec/authentication/credentials/RawCredentials.scala
+++ b/tsec-http4s/src/main/scala/tsec/authentication/credentials/RawCredentials.scala
@@ -1,0 +1,3 @@
+package tsec.authentication.credentials
+
+final case class RawCredentials[+U](identity: U, rawPassword: String)

--- a/tsec-http4s/src/main/scala/tsec/authentication/package.scala
+++ b/tsec-http4s/src/main/scala/tsec/authentication/package.scala
@@ -19,13 +19,13 @@ import scala.util.control.NonFatal
 package object authentication {
 
   trait BackingStore[F[_], I, V] {
-    def put(elem: V): F[Int]
+    def put(elem: V): F[V]
 
     def get(id: I): OptionT[F, V]
 
-    def update(v: V): F[Int]
+    def update(v: V): F[V]
 
-    def delete(id: I): F[Int]
+    def delete(id: I): F[Unit]
   }
 
   type AuthExtractorService[F[_], A, I] = Kleisli[OptionT[F, ?], Request[F], SecuredRequest[F, A, I]]

--- a/tsec-http4s/src/main/scala/tsec/authentication/package.scala
+++ b/tsec-http4s/src/main/scala/tsec/authentication/package.scala
@@ -104,7 +104,7 @@ package object authentication {
     * @param extension
     */
   final case class TSecCookieSettings(
-      cookieName: String,
+      cookieName: String = "tsec-auth-cookie",
       secure: Boolean,
       httpOnly: Boolean = true,
       domain: Option[String] = None,
@@ -115,7 +115,7 @@ package object authentication {
   )
 
   final case class TSecJWTSettings(
-      headerName: String,
+      headerName: String = "X-TSec-JWT",
       expirationTime: FiniteDuration,
       maxIdle: Option[FiniteDuration]
   )

--- a/tsec-http4s/src/main/scala/tsec/authorization/Authorization.scala
+++ b/tsec-http4s/src/main/scala/tsec/authorization/Authorization.scala
@@ -1,8 +1,24 @@
 package tsec.authorization
 
+import cats.Monad
 import cats.data.OptionT
+import cats.kernel.Monoid
 import tsec.authentication.SecuredRequest
 
 trait Authorization[F[_], Identity] {
   def isAuthorized[Auth](toAuth: SecuredRequest[F, Auth, Identity]): OptionT[F, SecuredRequest[F, Auth, Identity]]
+}
+
+object Authorization {
+  implicit def authorizationMonoid[F[_]: Monad, I]: Monoid[Authorization[F, I]] = new Monoid[Authorization[F, I]] {
+    def empty: Authorization[F, I] = new Authorization[F, I] {
+      def isAuthorized[Auth](toAuth: SecuredRequest[F, Auth, I]): OptionT[F, SecuredRequest[F, Auth, I]] =
+        OptionT.pure(toAuth)
+    }
+
+    def combine(x: Authorization[F, I], y: Authorization[F, I]): Authorization[F, I] = new Authorization[F, I] {
+      def isAuthorized[Auth](toAuth: SecuredRequest[F, Auth, I]): OptionT[F, SecuredRequest[F, Auth, I]] =
+        x.isAuthorized(toAuth).flatMap(y.isAuthorized)
+    }
+  }
 }

--- a/tsec-http4s/src/main/scala/tsec/authorization/BasicDAC.scala
+++ b/tsec-http4s/src/main/scala/tsec/authorization/BasicDAC.scala
@@ -9,19 +9,22 @@ import tsec.authentication.SecuredRequest
   * In this case, the user has to provide an `AuthGroup` for which groups are allowed to access the data,
   *
   * @param eq
-  * @tparam U
+  * @tparam G
   */
-abstract class BasicDAC[F[_], U](implicit eq: Eq[U], F: MonadError[F, Throwable]) extends Authorization[F, U] {
-  def fetchGroup(u: U): F[AuthGroup[U]]
+abstract class BasicDAC[F[_], G, U](implicit eq: Eq[G], F: MonadError[F, Throwable]) extends Authorization[F, U] {
+  def fetchGroup: F[AuthGroup[G]]
 
-  def fetchOwner[Auth](toAuth: SecuredRequest[F, Auth, U]): F[U]
+  def fetchOwner: F[G]
+
+  def fetchAccess[Auth](u: SecuredRequest[F, Auth, U]): F[G]
 
   def isAuthorized[Auth](toAuth: SecuredRequest[F, Auth, U]): OptionT[F, SecuredRequest[F, Auth, U]] = {
     val out = for {
-      owner <- fetchOwner[Auth](toAuth)
-      group <- fetchGroup(toAuth.identity)
+      owner  <- fetchOwner
+      group  <- fetchGroup
+      access <- fetchAccess[Auth](toAuth)
     } yield {
-      if (eq.eqv(toAuth.identity, owner) || group.contains(toAuth))
+      if (eq.eqv(access, owner) || group.contains(access))
         Some(toAuth)
       else
         None

--- a/tsec-http4s/src/main/scala/tsec/authorization/BasicRBAC.scala
+++ b/tsec-http4s/src/main/scala/tsec/authorization/BasicRBAC.scala
@@ -7,8 +7,8 @@ import cats.syntax.functor._
 
 import scala.reflect.ClassTag
 
-sealed abstract case class BasicRBAC[F[_], U, R](authorized: AuthGroup[R])(
-    implicit role: AuthorizationInfo[F, U, R],
+sealed abstract case class BasicRBAC[F[_], R, U](authorized: AuthGroup[R])(
+    implicit role: AuthorizationInfo[F, R, U],
     enum: SimpleAuthEnum[R, String],
     F: MonadError[F, Throwable]
 ) extends Authorization[F, U] {
@@ -27,23 +27,23 @@ sealed abstract case class BasicRBAC[F[_], U, R](authorized: AuthGroup[R])(
 }
 
 object BasicRBAC {
-  def apply[F[_], U, R: ClassTag](roles: R*)(
+  def apply[F[_], R: ClassTag, U](roles: R*)(
       implicit enum: SimpleAuthEnum[R, String],
-      role: AuthorizationInfo[F, U, R],
+      role: AuthorizationInfo[F, R, U],
       F: MonadError[F, Throwable]
-  ): BasicRBAC[F, U, R] =
-    fromGroup[F, U, R](AuthGroup(roles: _*))
+  ): BasicRBAC[F, R, U] =
+    fromGroup[F, R, U](AuthGroup(roles: _*))
 
-  def fromGroup[F[_], U, R: ClassTag](valueSet: AuthGroup[R])(
-      implicit role: AuthorizationInfo[F, U, R],
+  def fromGroup[F[_], R: ClassTag, U](valueSet: AuthGroup[R])(
+      implicit role: AuthorizationInfo[F, R, U],
       enum: SimpleAuthEnum[R, String],
       F: MonadError[F, Throwable]
-  ): BasicRBAC[F, U, R] = new BasicRBAC[F, U, R](valueSet) {}
+  ): BasicRBAC[F, R, U] = new BasicRBAC[F, R, U](valueSet) {}
 
-  def all[F[_], U, R: ClassTag](
+  def all[F[_], R: ClassTag, U](
       implicit enum: SimpleAuthEnum[R, String],
-      role: AuthorizationInfo[F, U, R],
+      role: AuthorizationInfo[F, R, U],
       F: MonadError[F, Throwable]
-  ): BasicRBAC[F, U, R] =
-    new BasicRBAC[F, U, R](enum.viewAll) {}
+  ): BasicRBAC[F, R, U] =
+    new BasicRBAC[F, R, U](enum.viewAll) {}
 }

--- a/tsec-http4s/src/main/scala/tsec/authorization/HierarchyAuth.scala
+++ b/tsec-http4s/src/main/scala/tsec/authorization/HierarchyAuth.scala
@@ -5,8 +5,8 @@ import cats.data.OptionT
 import tsec.authentication
 import cats.syntax.functor._
 
-sealed abstract case class HierarchyAuth[F[_], U, R](authLevel: Int)(
-    implicit role: AuthorizationInfo[F, U, R],
+sealed abstract case class HierarchyAuth[F[_], R, U](authLevel: R)(
+    implicit role: AuthorizationInfo[F, R, U],
     enum: SimpleAuthEnum[R, Int],
     F: MonadError[F, Throwable]
 ) extends Authorization[F, U] {
@@ -17,7 +17,7 @@ sealed abstract case class HierarchyAuth[F[_], U, R](authLevel: Int)(
     OptionT {
       role.fetchInfo(toAuth.identity).map { authRole =>
         val intRepr = enum.getRepr(authRole)
-        if (0 <= intRepr && intRepr <= authLevel && enum.contains(authRole))
+        if (0 <= intRepr && intRepr <= enum.getRepr(authLevel) && enum.contains(authRole))
           Some(toAuth)
         else
           None
@@ -27,13 +27,13 @@ sealed abstract case class HierarchyAuth[F[_], U, R](authLevel: Int)(
 
 object HierarchyAuth {
 
-  def apply[F[_], U, R](auth: Int)(
-      implicit role: AuthorizationInfo[F, U, R],
+  def apply[F[_], U, R](auth: R)(
+      implicit role: AuthorizationInfo[F, R, U],
       e: SimpleAuthEnum[R, Int],
       F: MonadError[F, Throwable]
-  ): F[HierarchyAuth[F, U, R]] =
-    if (auth < 0)
-      F.raiseError[HierarchyAuth[F, U, R]](InvalidAuthLevelError)
+  ): F[HierarchyAuth[F, R, U]] =
+    if (e.getRepr(auth) < 0)
+      F.raiseError[HierarchyAuth[F, R, U]](InvalidAuthLevelError)
     else
-      F.pure(new HierarchyAuth[F, U, R](auth) {})
+      F.pure(new HierarchyAuth[F, R, U](auth) {})
 }

--- a/tsec-http4s/src/main/scala/tsec/authorization/package.scala
+++ b/tsec-http4s/src/main/scala/tsec/authorization/package.scala
@@ -1,6 +1,7 @@
 package tsec
 
 import cats.evidence.Is
+import tsec.authorization.AuthGroup$$
 
 import scala.reflect.ClassTag
 
@@ -131,15 +132,16 @@ package object authorization {
     }
     def fromSeq[G: ClassTag](seq: Seq[G]): AuthGroup[G]       = AuthGroup$$.is[G].coerce(seq.distinct.toArray)
     def unsafeFromSeq[G: ClassTag](seq: Seq[G]): AuthGroup[G] = AuthGroup$$.is[G].coerce(seq.toArray)
+    def empty[G: ClassTag]: AuthGroup$$.AuthRepr[G] = AuthGroup$$.is[G].coerce(Array.empty[G])
   }
 
   /** A simple typeclass that allows us to propagate information that is required for authorization */
-  trait AuthorizationInfo[F[_], U, Role] {
+  trait AuthorizationInfo[F[_], Role, U] {
     def fetchInfo(u: U): F[Role]
   }
 
-  trait DynamicAuthGroup[F[_], U, Grp]{
-    def fetchGroupInfo(u: U): F[AuthGroup[Grp]]
+  trait DynamicAuthGroup[F[_], Grp]{
+    def fetchGroupInfo: F[AuthGroup[Grp]]
   }
 
   type InvalidAuthLevel = InvalidAuthLevelError.type

--- a/tsec-http4s/src/main/scala/tsec/cookies/CookieSigner.scala
+++ b/tsec-http4s/src/main/scala/tsec/cookies/CookieSigner.scala
@@ -17,16 +17,13 @@ object CookieSigner {
 
   def verify[A: MacTag: ByteEV](signed: SignedCookie[A], key: MacSigningKey[A])(
       implicit signer: JCAMacImpure[A]
-  ): MacErrorM[Boolean] = {
-    val split = signed.split("-")
-    if (split.length != 2)
-      Left(MacVerificationError("Invalid cookie"))
-    else {
-      val original = split(0).base64Bytes
-      val signed   = split(1).base64Bytes.toRepr[A]
-      signer.verify(original, signed, key)
+  ): MacErrorM[Boolean] =
+    signed.split("-") match {
+      case Array(original, signed) =>
+        signer.verify(original.base64Bytes, signed.base64Bytes.toRepr[A], key)
+      case _ =>
+        Left(MacVerificationError("Invalid cookie"))
     }
-  }
 
   def verifyAndRetrieve[A: MacTag: ByteEV](signed: SignedCookie[A], key: MacSigningKey[A])(
       implicit signer: JCAMacImpure[A]

--- a/tsec-http4s/src/main/scala/tsec/csrf/CSRFTokenSigner.scala
+++ b/tsec-http4s/src/main/scala/tsec/csrf/CSRFTokenSigner.scala
@@ -1,22 +1,63 @@
 package tsec.csrf
 
+import java.security.MessageDigest
+import java.time.Clock
+
+import cats.data.OptionT
 import cats.effect.Sync
 import tsec.common.ByteEV
 import tsec.mac.imports.{JCAMacPure, MacTag}
+import tsec.common._
+import tsec.mac._
+import tsec.mac.imports._
+import cats.syntax.all._
 
 /** A CSRF Token Signer, adapted from:
   * https://github.com/playframework/playframework/blob/master/framework/src/play/src/main/scala/play/api/libs/crypto/CSRFTokenSigner.scala
   * by Will Sargent, to use the tsec crypto primitives
   *
+  * Also very similar to cryptobits, but with a variable argument mac signer, thus we have more than
+  * one mac algorithm to choose from
+  *
   */
-sealed abstract class CSRFTokenSigner[F[_]: Sync, A: MacTag: ByteEV](token: CSRFToken, headerName: String)(implicit mac: JCAMacPure[F, A]) {
+final case class CSRFTokenSigner[F[_]: Sync, A: MacTag: ByteEV](
+    key: MacSigningKey[A],
+    tokenLength: Int = 16,
+    clock: Clock = Clock.systemUTC()
+)(
+    implicit mac: JCAMacPure[F, A]
+) {
 
-//  def checkAndSign(token: CSRFToken) = {
-//    token.split("-") match {
-//      case Array(token:)
-//
-//    }
-//
-//  }
+  def isEqual(s1: String, s2: String): Boolean =
+    MessageDigest.isEqual(s1.utf8Bytes, s2.utf8Bytes)
+
+  def signToken(string: String): F[CSRFToken] = {
+    val joined = string + "-" + clock.millis()
+    mac.sign(joined.utf8Bytes, key).map(s => CSRFToken(joined + "-" + s.asByteArray.toUtf8String))
+  }
+
+  def generateNewToken: F[CSRFToken] =
+    signToken(CSRFToken.generateHexBase(tokenLength))
+
+  /**
+    * Extract a signed token
+    */
+  def extractRaw(token: CSRFToken): OptionT[F, String] =
+    token.split("-", 3) match {
+      case Array(raw, nonce, signed) =>
+        OptionT(
+          mac
+            .sign((raw + "-" + nonce).utf8Bytes, key)
+            .map(f => if (MessageDigest.isEqual(f.asByteArray, signed.utf8Bytes)) Some(raw) else None)
+        )
+      case _ =>
+        OptionT.none
+    }
+
+  def checkEqual(token1: CSRFToken, token2: CSRFToken): F[Boolean] =
+    (for {
+      raw1 <- extractRaw(token1)
+      raw2 <- extractRaw(token2)
+    } yield isEqual(raw1, raw2)).getOrElse(false)
 
 }

--- a/tsec-http4s/src/main/scala/tsec/csrf/CSRFTokenSigner.scala
+++ b/tsec-http4s/src/main/scala/tsec/csrf/CSRFTokenSigner.scala
@@ -1,16 +1,22 @@
 package tsec.csrf
 
 import cats.effect.Sync
-import tsec.mac.imports.MacTag
-import tsec.mac.imports.threadlocal.JMacPureI
+import tsec.common.ByteEV
+import tsec.mac.imports.{JCAMacPure, MacTag}
 
 /** A CSRF Token Signer, adapted from:
   * https://github.com/playframework/playframework/blob/master/framework/src/play/src/main/scala/play/api/libs/crypto/CSRFTokenSigner.scala
   * by Will Sargent, to use the tsec crypto primitives
   *
   */
-sealed abstract class CSRFTokenSigner[F[_]: Sync, A: MacTag](token: String, headerName: String)(implicit mac: JMacPureI[A]) {
+sealed abstract class CSRFTokenSigner[F[_]: Sync, A: MacTag: ByteEV](token: CSRFToken, headerName: String)(implicit mac: JCAMacPure[F, A]) {
 
-  def sign
+//  def checkAndSign(token: CSRFToken) = {
+//    token.split("-") match {
+//      case Array(token:)
+//
+//    }
+//
+//  }
 
 }

--- a/tsec-http4s/src/main/scala/tsec/csrf/CSRFTokenSigner.scala
+++ b/tsec-http4s/src/main/scala/tsec/csrf/CSRFTokenSigner.scala
@@ -1,0 +1,16 @@
+package tsec.csrf
+
+import cats.effect.Sync
+import tsec.mac.imports.MacTag
+import tsec.mac.imports.threadlocal.JMacPureI
+
+/** A CSRF Token Signer, adapted from:
+  * https://github.com/playframework/playframework/blob/master/framework/src/play/src/main/scala/play/api/libs/crypto/CSRFTokenSigner.scala
+  * by Will Sargent, to use the tsec crypto primitives
+  *
+  */
+sealed abstract class CSRFTokenSigner[F[_]: Sync, A: MacTag](token: String, headerName: String)(implicit mac: JMacPureI[A]) {
+
+  def sign
+
+}

--- a/tsec-http4s/src/main/scala/tsec/csrf/TSecCSRF.scala
+++ b/tsec-http4s/src/main/scala/tsec/csrf/TSecCSRF.scala
@@ -78,11 +78,9 @@ final case class TSecCSRF[F[_]: Sync, A: MacTag: ByteEV](
         } yield res
     }
 
-  def withNewToken: CSRFMiddleware[F] = _.andThen(embed _)
+  def withNewToken: CSRFMiddleware[F] = _.andThen(r => OptionT.liftF(embed(r)))
 
-  def embed(response: Response[F]): OptionT[F, Response[F]] =
-    OptionT.liftF(
+  def embed(response: Response[F]): F[Response[F]] =
       generateNewToken.map(t => response.addCookie(Cookie(name = cookieName, content = t, httpOnly = true)))
-    )
 
 }

--- a/tsec-http4s/src/main/scala/tsec/csrf/TSecCSRF.scala
+++ b/tsec-http4s/src/main/scala/tsec/csrf/TSecCSRF.scala
@@ -3,7 +3,7 @@ package tsec.csrf
 import java.security.MessageDigest
 import java.time.Clock
 
-import cats.data.OptionT
+import cats.data.{Kleisli, OptionT}
 import cats.effect.Sync
 import tsec.common.ByteEV
 import tsec.mac.imports.{JCAMacPure, MacTag}
@@ -11,6 +11,9 @@ import tsec.common._
 import tsec.mac._
 import tsec.mac.imports._
 import cats.syntax.all._
+import org.http4s.{Cookie, Request, Response, Status}
+import org.http4s.util.CaseInsensitiveString
+import tsec.authentication.cookieFromRequest
 
 /** A CSRF Token Signer, adapted from:
   * https://github.com/playframework/playframework/blob/master/framework/src/play/src/main/scala/play/api/libs/crypto/CSRFTokenSigner.scala
@@ -20,8 +23,10 @@ import cats.syntax.all._
   * one mac algorithm to choose from
   *
   */
-final case class CSRFTokenSigner[F[_]: Sync, A: MacTag: ByteEV](
+final case class TSecCSRF[F[_]: Sync, A: MacTag: ByteEV](
     key: MacSigningKey[A],
+    headerName: String = "X-TSec-Csrf",
+    cookieName: String = "tsec-csrf",
     tokenLength: Int = 16,
     clock: Clock = Clock.systemUTC()
 )(
@@ -33,7 +38,7 @@ final case class CSRFTokenSigner[F[_]: Sync, A: MacTag: ByteEV](
 
   def signToken(string: String): F[CSRFToken] = {
     val joined = string + "-" + clock.millis()
-    mac.sign(joined.utf8Bytes, key).map(s => CSRFToken(joined + "-" + s.asByteArray.toUtf8String))
+    mac.sign(joined.utf8Bytes, key).map(s => CSRFToken(joined + "-" + s.asByteArray.toB64UrlString))
   }
 
   def generateNewToken: F[CSRFToken] =
@@ -48,16 +53,36 @@ final case class CSRFTokenSigner[F[_]: Sync, A: MacTag: ByteEV](
         OptionT(
           mac
             .sign((raw + "-" + nonce).utf8Bytes, key)
-            .map(f => if (MessageDigest.isEqual(f.asByteArray, signed.utf8Bytes)) Some(raw) else None)
+            .map(
+              f => if (MessageDigest.isEqual(f.asByteArray, signed.base64UrlBytes)) Some(raw) else None
+            )
         )
       case _ =>
         OptionT.none
     }
 
-  def checkEqual(token1: CSRFToken, token2: CSRFToken): F[Boolean] =
-    (for {
+  def checkEqual(token1: CSRFToken, token2: CSRFToken): OptionT[F, Boolean] =
+    for {
       raw1 <- extractRaw(token1)
       raw2 <- extractRaw(token2)
-    } yield isEqual(raw1, raw2)).getOrElse(false)
+    } yield isEqual(raw1, raw2)
+
+  def apply: CSRFMiddleware[F] =
+    req =>
+      Kleisli { r: Request[F] =>
+        for {
+          c1  <- cookieFromRequest[F](cookieName, r)
+          c2  <- OptionT.fromOption[F](r.headers.get(CaseInsensitiveString(headerName)).map(_.value))
+          eq  <- checkEqual(CSRFToken(c1.content), CSRFToken(c2))
+          res <- if (eq) req(r) else OptionT.pure(Response[F](Status.Forbidden))
+        } yield res
+    }
+
+  def withNewToken: CSRFMiddleware[F] = _.andThen(embed _)
+
+  def embed(response: Response[F]): OptionT[F, Response[F]] =
+    OptionT.liftF(
+      generateNewToken.map(t => response.addCookie(Cookie(name = cookieName, content = t, httpOnly = true)))
+    )
 
 }

--- a/tsec-http4s/src/main/scala/tsec/csrf/package.scala
+++ b/tsec-http4s/src/main/scala/tsec/csrf/package.scala
@@ -5,7 +5,7 @@ import java.util.concurrent.atomic.LongAdder
 
 import cats.evidence.Is
 import org.bouncycastle.util.encoders.Hex
-import tsec.common.TaggedString
+import tsec.common.{ManagedRandom, TaggedString}
 
 package object csrf {
 
@@ -16,39 +16,16 @@ package object csrf {
 
   type CSRFToken = CSRFToken$$.I
 
-  object CSRFToken {
+  object CSRFToken extends ManagedRandom {
 
     @inline def is: Is[CSRFToken, String] = CSRFToken$$.is
 
-    /** Cache our random, and seed it properly as per
-      * https://tersesystems.com/2015/12/17/the-right-way-to-use-securerandom/
-      */
-    private val cachedRand: SecureRandom = {
-      val r = new SecureRandom()
-      r.nextBytes(new Array[Byte](20))
-      r
-    }
+    def apply(s: String): CSRFToken = is.flip.coerce(s)
 
-    /** We will keep a reference to how many times our random is utilized
-      * After a sensible Integer.MaxValue/10 times, we should reseed, so roughly every 100 million tokens
-      */
-    private val adder: LongAdder = new LongAdder
-    private val MaxBeforeReseed  = (Integer.MAX_VALUE / 10).toLong
-
-    private def reSeed(): Unit = {
-      adder.reset()
-      cachedRand.nextBytes(new Array[Byte](20))
-    }
-
-    def apply(tokenLength: Int = 16): CSRFToken = {
+    def generateHexBase(tokenLength: Int = 16): String = {
       val tokenBytes = new Array[Byte](tokenLength)
-
-      adder.increment()
-      if (adder.sum() >= MaxBeforeReseed)
-        reSeed()
-
-      cachedRand.nextBytes(tokenBytes)
-      is.flip.coerce(Hex.toHexString(tokenBytes))
+      nextBytes(tokenBytes)
+      Hex.toHexString(tokenBytes)
     }
   }
 

--- a/tsec-http4s/src/main/scala/tsec/csrf/package.scala
+++ b/tsec-http4s/src/main/scala/tsec/csrf/package.scala
@@ -1,0 +1,55 @@
+package tsec
+
+import java.security.SecureRandom
+import java.util.concurrent.atomic.LongAdder
+
+import cats.evidence.Is
+import org.bouncycastle.util.encoders.Hex
+import tsec.common.TaggedString
+
+package object csrf {
+
+  protected val CSRFToken$$ : TaggedString = new TaggedString {
+    type I = String
+    val is: Is[I, String] = Is.refl[I]
+  }
+
+  type CSRFToken = CSRFToken$$.I
+
+  object CSRFToken {
+
+    @inline def is: Is[CSRFToken, String] = CSRFToken$$.is
+
+    /** Cache our random, and seed it properly as per
+      * https://tersesystems.com/2015/12/17/the-right-way-to-use-securerandom/
+      */
+    private val cachedRand: SecureRandom = {
+      val r = new SecureRandom()
+      r.nextBytes(new Array[Byte](20))
+      r
+    }
+
+    /** We will keep a reference to how many times our random is utilized
+      * After a sensible Integer.MaxValue/10 times, we should reseed, so roughly every 100 million tokens
+      */
+    private val adder: LongAdder = new LongAdder
+    private val MaxBeforeReseed  = (Integer.MAX_VALUE / 10).toLong
+
+    private def reSeed(): Unit = {
+      adder.reset()
+      cachedRand.nextBytes(new Array[Byte](20))
+    }
+
+    def apply(tokenLength: Int = 16): CSRFToken = {
+      val tokenBytes = new Array[Byte](tokenLength)
+
+      adder.increment()
+      if (adder.sum() >= MaxBeforeReseed)
+        reSeed()
+
+      cachedRand.nextBytes(tokenBytes)
+      is.flip.coerce(Hex.toHexString(tokenBytes))
+    }
+  }
+
+}

--- a/tsec-http4s/src/main/scala/tsec/csrf/package.scala
+++ b/tsec-http4s/src/main/scala/tsec/csrf/package.scala
@@ -3,8 +3,11 @@ package tsec
 import java.security.SecureRandom
 import java.util.concurrent.atomic.LongAdder
 
+import cats.data.OptionT
 import cats.evidence.Is
 import org.bouncycastle.util.encoders.Hex
+import org.http4s.{Request, Response}
+import org.http4s.server.Middleware
 import tsec.common.{ManagedRandom, TaggedString}
 
 package object csrf {
@@ -28,5 +31,8 @@ package object csrf {
       Hex.toHexString(tokenBytes)
     }
   }
+
+  type CSRFMiddleware[F[_]] =
+    Middleware[OptionT[F, ?], Request[F], Response[F], Request[F], Response[F]]
 
 }

--- a/tsec-http4s/src/test/scala/tsec/authentication/AuthenticatorSpec.scala
+++ b/tsec-http4s/src/test/scala/tsec/authentication/AuthenticatorSpec.scala
@@ -37,23 +37,22 @@ object DummyUser {
   * This contains utilities that are not present currently under the `Authenticator`
   * class that are necessary for testing.
   *
-  * @tparam A
   */
-protected[authentication] abstract case class AuthSpecTester[A, Auth[_]](
-    auth: Authenticator[IO, A, Int, DummyUser, Auth],
+protected[authentication] abstract case class AuthSpecTester[Auth](
+    auth: Authenticator[IO, Int, DummyUser, Auth],
     dummyStore: BackingStore[IO, Int, DummyUser]
 ) {
 
-  def embedInRequest(request: Request[IO], authenticator: Auth[A]): Request[IO]
+  def embedInRequest(request: Request[IO], authenticator: Auth): Request[IO]
 
-  def expireAuthenticator(b: Auth[A]): OptionT[IO, Auth[A]]
+  def expireAuthenticator(b: Auth): OptionT[IO, Auth]
 
-  def timeoutAuthenticator(b: Auth[A]): OptionT[IO, Auth[A]]
+  def timeoutAuthenticator(b: Auth): OptionT[IO, Auth]
 
-  def wrongKeyAuthenticator: OptionT[IO, Auth[A]]
+  def wrongKeyAuthenticator: OptionT[IO, Auth]
 }
 
-abstract class AuthenticatorSpec[B[_]] extends TestSpec with MustMatchers with PropertyChecks with BeforeAndAfterEach {
+abstract class AuthenticatorSpec extends TestSpec with MustMatchers with PropertyChecks with BeforeAndAfterEach {
 
   implicit val genDummy: Arbitrary[DummyUser] = Arbitrary(for {
     i <- Gen.chooseNum[Int](0, Int.MaxValue)
@@ -88,7 +87,7 @@ abstract class AuthenticatorSpec[B[_]] extends TestSpec with MustMatchers with P
     def dAll(): Unit = storageMap.clear()
   }
 
-  def AuthenticatorTest[A](title: String, authSpec: AuthSpecTester[A, B]) = {
+  def AuthenticatorTest[A](title: String, authSpec: AuthSpecTester[A]) = {
     behavior of title
 
     it should "Create, embed and extract properly" in {

--- a/tsec-http4s/src/test/scala/tsec/authentication/AuthenticatorSpec.scala
+++ b/tsec-http4s/src/test/scala/tsec/authentication/AuthenticatorSpec.scala
@@ -17,18 +17,22 @@ import scala.collection.mutable
 sealed abstract case class DummyRole(repr: String)
 object DummyRole extends SimpleAuthEnum[DummyRole, String] {
   implicit object Admin extends DummyRole("Admin")
+  implicit object User  extends DummyRole("User")
   implicit object Other extends DummyRole("Other")
   implicit object Err   extends DummyRole("Err")
 
   val getRepr: (DummyRole) => String         = _.repr
   protected val values: AuthGroup[DummyRole] = AuthGroup(Admin, Other)
   val orElse: DummyRole                      = Err
+  implicit val eq: Eq[DummyRole] = new Eq[DummyRole] {
+    def eqv(x: DummyRole, y: DummyRole): Boolean = x == y
+  }
 }
 
 case class DummyUser(id: Int, name: String = "bob", role: DummyRole = DummyRole.Other)
 
 object DummyUser {
-  implicit val role: AuthorizationInfo[IO, DummyUser, DummyRole] = new AuthorizationInfo[IO, DummyUser, DummyRole] {
+  implicit val role: AuthorizationInfo[IO, DummyRole, DummyUser] = new AuthorizationInfo[IO, DummyRole, DummyUser] {
     def fetchInfo(u: DummyUser): IO[DummyRole] = IO.pure(u.role)
   }
 }

--- a/tsec-http4s/src/test/scala/tsec/authentication/AuthenticatorSpec.scala
+++ b/tsec-http4s/src/test/scala/tsec/authentication/AuthenticatorSpec.scala
@@ -65,9 +65,9 @@ abstract class AuthenticatorSpec extends TestSpec with MustMatchers with Propert
     def put(elem: V): F[Int] = {
       val map = storageMap.put(getId(elem), elem)
       if (map.isEmpty)
-        F.pure(0)
-      else
         F.pure(1)
+      else
+        F.pure(0)
     }
 
     def get(id: I): OptionT[F, V] =
@@ -93,10 +93,10 @@ abstract class AuthenticatorSpec extends TestSpec with MustMatchers with Propert
     it should "Create, embed and extract properly" in {
       forAll { (dummy1: DummyUser) =>
         val results = (for {
-          _            <- OptionT.liftF(authSpec.dummyStore.put(dummy1))
-          auth         <- authSpec.auth.create(dummy1.id)
-          fromRequest  <- authSpec.auth.extractAndValidate(authSpec.embedInRequest(Request[IO](), auth))
-          _            <- OptionT.liftF(authSpec.dummyStore.delete(dummy1.id))
+          _           <- OptionT.liftF(authSpec.dummyStore.put(dummy1))
+          auth        <- authSpec.auth.create(dummy1.id)
+          fromRequest <- authSpec.auth.extractAndValidate(authSpec.embedInRequest(Request[IO](), auth))
+          _           <- OptionT.liftF(authSpec.dummyStore.delete(dummy1.id))
         } yield fromRequest)
           .handleErrorWith(_ => OptionT.none)
           .value

--- a/tsec-http4s/src/test/scala/tsec/authentication/AuthorizationTests.scala
+++ b/tsec-http4s/src/test/scala/tsec/authentication/AuthorizationTests.scala
@@ -1,0 +1,156 @@
+package tsec.authentication
+
+import cats.effect.IO
+import org.http4s.Request
+import org.scalatest.MustMatchers
+import tsec.TestSpec
+import tsec.authentication.DummyRole.{Admin, Other}
+import tsec.authorization._
+import cats.implicits._
+
+final case class AuthDummyUser(id: Int, role: DummyRole, authLevel: AuthLevel = AuthLevel.CEO)
+
+object AuthDummyUser {
+  implicit val authInfo1: AuthorizationInfo[IO, DummyRole, AuthDummyUser] =
+    new AuthorizationInfo[IO, DummyRole, AuthDummyUser] {
+      def fetchInfo(u: AuthDummyUser): IO[DummyRole] = IO.pure(u.role)
+    }
+
+  implicit val authInfo2: AuthorizationInfo[IO, AuthLevel, AuthDummyUser] =
+    new AuthorizationInfo[IO, AuthLevel, AuthDummyUser] {
+      def fetchInfo(u: AuthDummyUser): IO[AuthLevel] = IO.pure(u.authLevel)
+    }
+}
+
+sealed case class AuthLevel(i: Int)
+object AuthLevel extends SimpleAuthEnum[AuthLevel, Int] {
+  implicit object CEO           extends AuthLevel(0)
+  implicit object Staff         extends AuthLevel(1)
+  implicit object AugmentedUser extends AuthLevel(2)
+  implicit object RegularUser   extends AuthLevel(3)
+  implicit object Err           extends AuthLevel(-1)
+
+  val getRepr: (AuthLevel) => Int            = _.i
+  protected val values: AuthGroup[AuthLevel] = AuthGroup(CEO, Staff, AugmentedUser, RegularUser)
+  val orElse: AuthLevel                      = Err
+}
+
+class AuthorizationTests extends TestSpec with MustMatchers {
+
+  val basicRBAC = BasicRBAC[IO, DummyRole, AuthDummyUser](Admin, Other)
+
+  val dummyRequest = Request[IO]()
+
+  behavior of "BasicRBAC"
+
+  it should "let a request pass through if in group" in {
+    val dummySreq = SecuredRequest[IO, Int, AuthDummyUser](dummyRequest, 0, AuthDummyUser(0, Admin))
+    basicRBAC.isAuthorized(dummySreq).value.unsafeRunSync() mustBe Some(dummySreq)
+  }
+
+  it should "not let a request pass through if not contained" in {
+    val dummySreq = SecuredRequest[IO, Int, AuthDummyUser](dummyRequest, 0, AuthDummyUser(0, DummyRole.User))
+    basicRBAC.isAuthorized(dummySreq).value.unsafeRunSync() mustBe None
+  }
+
+  behavior of "BasicDAC"
+
+  val basicDAC = new BasicDAC[IO, Int, AuthDummyUser] {
+    def fetchGroup: IO[AuthGroup[Int]] = IO.pure(AuthGroup(4, 5, 6))
+
+    def fetchOwner: IO[Int] = IO.pure(1)
+
+    def fetchAccess[Auth](u: SecuredRequest[IO, Auth, AuthDummyUser]): IO[Int] = IO.pure(u.identity.id)
+  }
+
+  it should "let a request pass if owner but not in group" in {
+    val dummySreq = SecuredRequest[IO, Int, AuthDummyUser](dummyRequest, 0, AuthDummyUser(1, DummyRole.User))
+    basicDAC.isAuthorized(dummySreq).value.unsafeRunSync() mustBe Some(dummySreq)
+  }
+
+  it should "let a request pass if in group but not owner" in {
+    val dummySreq = SecuredRequest[IO, Int, AuthDummyUser](dummyRequest, 0, AuthDummyUser(4, DummyRole.User))
+    basicDAC.isAuthorized(dummySreq).value.unsafeRunSync() mustBe Some(dummySreq)
+  }
+
+  it should "not let the request pass if in neither" in {
+    val dummySreq = SecuredRequest[IO, Int, AuthDummyUser](dummyRequest, 0, AuthDummyUser(14, DummyRole.User))
+    basicDAC.isAuthorized(dummySreq).value.unsafeRunSync() mustBe None
+  }
+
+  behavior of "HierarchyAuth"
+
+  implicit val authInfo = new AuthorizationInfo[IO, AuthLevel, AuthLevel] {
+    def fetchInfo(u: AuthLevel): IO[AuthLevel] = IO.pure(u)
+  }
+
+  val hierarchyAuth = HierarchyAuth[IO, AuthLevel, AuthLevel](AuthLevel.Staff).unsafeRunSync()
+
+  it should "let a user with lower than the required clearance pass" in {
+    val dummySReq = SecuredRequest[IO, Int, AuthLevel](dummyRequest, 0, AuthLevel.CEO)
+    hierarchyAuth.isAuthorized[Int](dummySReq).value.unsafeRunSync() mustBe Some(dummySReq)
+  }
+
+  it should "let a user with equal clearance pass" in {
+    val dummySReq = SecuredRequest[IO, Int, AuthLevel](dummyRequest, 0, AuthLevel.Staff)
+    hierarchyAuth.isAuthorized[Int](dummySReq).value.unsafeRunSync() mustBe Some(dummySReq)
+  }
+
+  it should "not a user with equal clearance pass" in {
+    val dummySReq = SecuredRequest[IO, Int, AuthLevel](dummyRequest, 0, AuthLevel.AugmentedUser)
+    hierarchyAuth.isAuthorized[Int](dummySReq).value.unsafeRunSync() mustBe None
+  }
+
+  behavior of "DynamicRBAC"
+
+  val dynamicAuthGroup = new DynamicAuthGroup[IO, DummyRole] {
+    def fetchGroupInfo: IO[AuthGroup[DummyRole]] = IO.pure(AuthGroup(DummyRole.Admin, DummyRole.User))
+  }
+
+  val dynamicRBAC = DynamicRBAC[IO, DummyRole, AuthDummyUser](dynamicAuthGroup)
+
+  it should "let a request pass through if in group" in {
+    val dummySreq = SecuredRequest[IO, Int, AuthDummyUser](dummyRequest, 0, AuthDummyUser(0, Admin))
+    dynamicRBAC.isAuthorized(dummySreq).value.unsafeRunSync() mustBe Some(dummySreq)
+  }
+
+  it should "not let a request pass through if not contained" in {
+    val dummySreq = SecuredRequest[IO, Int, AuthDummyUser](dummyRequest, 0, AuthDummyUser(0, DummyRole.User))
+    dynamicRBAC.isAuthorized(dummySreq).value.unsafeRunSync() mustBe None
+  }
+
+  behavior of "Bell La Padula"
+  val readAction  = BLPReadAction[IO, AuthLevel, AuthDummyUser](AuthLevel.Staff).unsafeRunSync()
+  val writeAction = BLPWriteAction[IO, AuthLevel, AuthDummyUser](AuthLevel.Staff).unsafeRunSync()
+
+  it should "read same level" in {
+    val dummySReq = SecuredRequest(dummyRequest, 0, AuthDummyUser(0, DummyRole.Admin, AuthLevel.Staff))
+    readAction.isAuthorized[Int](dummySReq).value.unsafeRunSync() mustBe Some(dummySReq)
+  }
+
+  it should "read lower level" in {
+    val dummySReq = SecuredRequest(dummyRequest, 0, AuthDummyUser(0, DummyRole.Admin, AuthLevel.Staff))
+    (for {
+      ra <- BLPReadAction[IO, AuthLevel, AuthDummyUser](AuthLevel.RegularUser)
+      r  <- ra.isAuthorized(dummySReq).value
+    } yield r).unsafeRunSync() mustBe Some(dummySReq)
+  }
+  it should "not read up" in {
+    val dummySReq = SecuredRequest(dummyRequest, 0, AuthDummyUser(0, DummyRole.Admin, AuthLevel.AugmentedUser))
+    readAction.isAuthorized[Int](dummySReq).value.unsafeRunSync() mustBe None
+  }
+
+  it should "only write same level" in {
+    val dummySReq = SecuredRequest(dummyRequest, 0, AuthDummyUser(0, DummyRole.Admin, AuthLevel.Staff))
+    (for {
+      r1 <- writeAction.isAuthorized(dummySReq).value
+      r2 <- writeAction
+        .isAuthorized(SecuredRequest(dummyRequest, 0, AuthDummyUser(0, DummyRole.Admin, AuthLevel.CEO)))
+        .value
+      r3 <- writeAction
+        .isAuthorized(SecuredRequest(dummyRequest, 0, AuthDummyUser(0, DummyRole.Admin, AuthLevel.AugmentedUser)))
+        .value
+    } yield (r1, r2, r3)).unsafeRunSync() mustBe ((Some(dummySReq), None, None))
+  }
+
+}

--- a/tsec-http4s/src/test/scala/tsec/authentication/BearerTokenAuthenticatorTests.scala
+++ b/tsec-http4s/src/test/scala/tsec/authentication/BearerTokenAuthenticatorTests.scala
@@ -1,0 +1,40 @@
+package tsec.authentication
+
+import java.time.Instant
+
+import cats.data.OptionT
+import cats.effect.IO
+import org.http4s.headers.Authorization
+import org.http4s.{AuthScheme, Credentials, Request}
+import tsec.common.SecureRandomId
+
+import scala.collection.mutable
+import scala.concurrent.duration._
+
+class BearerTokenAuthenticatorTests extends RequestAuthenticatorSpec {
+
+  def authspecTester = {
+    val tokenStore: BackingStore[IO, SecureRandomId, TSecBearerToken[Int]] =
+      dummyBackingStore[IO, SecureRandomId, TSecBearerToken[Int]](s => SecureRandomId.coerce(s.id))
+    val dummyStore    = dummyBackingStore[IO, Int, DummyUser](_.id)
+    val settings      = TSecTokenSettings(10.minutes, Some(10.minutes))
+    val authenticator = BearerTokenAuthenticator(tokenStore, dummyStore, settings)
+    new AuthSpecTester[TSecBearerToken[Int]](authenticator, dummyStore) {
+      def embedInRequest(request: Request[IO], authenticator: TSecBearerToken[Int]): Request[IO] =
+        request.putHeaders(Authorization(Credentials.Token(AuthScheme.Bearer, authenticator.id)))
+
+      def expireAuthenticator(b: TSecBearerToken[Int]): OptionT[IO, TSecBearerToken[Int]] =
+        authenticator.update(b.copy(expiry = Instant.now.minusSeconds(30)))
+
+      def timeoutAuthenticator(b: TSecBearerToken[Int]): OptionT[IO, TSecBearerToken[Int]] =
+        authenticator.update(b.copy(lastTouched = Some(Instant.now.minusSeconds(300000))))
+
+      def wrongKeyAuthenticator: OptionT[IO, TSecBearerToken[Int]] =
+        OptionT.none
+    }
+  }
+
+  AuthenticatorTest("Bearer token authenticator", authspecTester)
+  requestAuthTests[TSecBearerToken[Int]]("Bearer token Request handler", authspecTester)
+
+}

--- a/tsec-http4s/src/test/scala/tsec/authentication/CSRFSpec.scala
+++ b/tsec-http4s/src/test/scala/tsec/authentication/CSRFSpec.scala
@@ -1,0 +1,91 @@
+package tsec.authentication
+
+import cats.data.OptionT
+import cats.effect.IO
+import tsec.TestSpec
+import tsec.common.ByteEV
+import tsec.mac.imports._
+import cats.syntax.all._
+import org.http4s.{Header, Headers, HttpService, Request, Response, Status}
+import org.scalatest.MustMatchers
+import tsec.csrf.TSecCSRF
+import org.http4s.dsl.io._
+
+class CSRFSpec extends TestSpec with MustMatchers {
+
+  val dummyService: HttpService[IO] = HttpService[IO] {
+    case GET -> Root =>
+      Ok()
+  }
+
+  val dummyRequest: Request[IO] = Request[IO]()
+  val orElse: Response[IO]      = Response[IO](Status.Forbidden)
+
+  def testCSRFWithMac[A: ByteEV: MacTag](implicit keygen: MacKeyGenerator[A]) = {
+    behavior of s"csrf signing using " + MacTag[A].algorithm
+
+    val newKey   = keygen.generateKeyUnsafe()
+    val tsecCSRF = TSecCSRF[IO, A](newKey)
+
+    it should "check for an equal token properly" in {
+      (for {
+        t  <- OptionT.liftF(tsecCSRF.generateNewToken)
+        eq <- tsecCSRF.checkEqual(t, t)
+      } yield eq).getOrElse(false).unsafeRunSync() mustBe true
+    }
+
+    it should "not validate different tokens" in {
+      (for {
+        t1 <- OptionT.liftF(tsecCSRF.generateNewToken)
+        t2 <- OptionT.liftF(tsecCSRF.generateNewToken)
+        eq <- tsecCSRF.checkEqual(t1, t2)
+      } yield eq).getOrElse(false).unsafeRunSync() mustBe false
+    }
+
+    behavior of s"CSRF middleware using " + MacTag[A].algorithm
+
+    it should "validate for the correct csrf token" in {
+      (for {
+        token <- OptionT.liftF(tsecCSRF.generateNewToken)
+        res <- tsecCSRF.apply(dummyService)(
+          dummyRequest.withHeaders(Headers(Header(tsecCSRF.headerName, token))).addCookie(tsecCSRF.cookieName, token)
+        )
+      } yield res).getOrElse(orElse).unsafeRunSync().status mustBe Status.Ok
+    }
+
+    it should "not validate if token is missing in both" in {
+      (for {
+        res <- tsecCSRF.apply(dummyService)(dummyRequest)
+      } yield res).getOrElse(orElse).unsafeRunSync().status mustBe Status.Forbidden
+    }
+
+    it should "not validate for token missing in header" in {
+      (for {
+        token <- OptionT.liftF(tsecCSRF.generateNewToken)
+        res <- tsecCSRF.apply(dummyService)(
+          dummyRequest.addCookie(tsecCSRF.cookieName, token)
+        )
+      } yield res).getOrElse(orElse).unsafeRunSync().status mustBe Status.Forbidden
+    }
+
+    it should "not validate for token missing in cookie" in {
+      (for {
+        token <- OptionT.liftF(tsecCSRF.generateNewToken)
+        res <- tsecCSRF.apply(dummyService)(
+          dummyRequest.withHeaders(Headers(Header(tsecCSRF.headerName, token)))
+        )
+      } yield res).getOrElse(orElse).unsafeRunSync().status mustBe Status.Forbidden
+    }
+
+    it should "not validate for different tokens" in {
+      (for {
+        token1 <- OptionT.liftF(tsecCSRF.generateNewToken)
+        token2 <- OptionT.liftF(tsecCSRF.generateNewToken)
+        res <- tsecCSRF.apply(dummyService)(
+          dummyRequest.withHeaders(Headers(Header(tsecCSRF.headerName, token1))).addCookie(tsecCSRF.cookieName, token2)
+        )
+      } yield res).getOrElse(orElse).unsafeRunSync().status mustBe Status.Forbidden
+    }
+  }
+
+}

--- a/tsec-http4s/src/test/scala/tsec/authentication/CSRFTests.scala
+++ b/tsec-http4s/src/test/scala/tsec/authentication/CSRFTests.scala
@@ -1,0 +1,12 @@
+package tsec.authentication
+
+import tsec.mac.imports._
+
+class CSRFTests extends CSRFSpec{
+
+  testCSRFWithMac[HMACSHA1]
+  testCSRFWithMac[HMACSHA256]
+  testCSRFWithMac[HMACSHA384]
+  testCSRFWithMac[HMACSHA512]
+
+}

--- a/tsec-http4s/src/test/scala/tsec/authentication/CookieAuthenticatorTests.scala
+++ b/tsec-http4s/src/test/scala/tsec/authentication/CookieAuthenticatorTests.scala
@@ -60,7 +60,7 @@ class CookieAuthenticatorTests extends RequestAuthenticatorSpec {
     AuthenticatorTest[AuthenticatedCookie[A, Int]](string, auth)
 
   def CookieReqTest[A: MacTag: ByteEV](string: String, auth: AuthSpecTester[AuthenticatedCookie[A, Int]]) =
-    RequestAuthTests[AuthenticatedCookie[A, Int]](string, auth)
+    requestAuthTests[AuthenticatedCookie[A, Int]](string, auth)
 
   CookieAuthTest[HMACSHA1]("HMACSHA1 Authenticator", genAuthenticator[HMACSHA1])
   CookieAuthTest[HMACSHA256]("HMACSHA256 Authenticator", genAuthenticator[HMACSHA256])

--- a/tsec-http4s/src/test/scala/tsec/authentication/CookieAuthenticatorTests.scala
+++ b/tsec-http4s/src/test/scala/tsec/authentication/CookieAuthenticatorTests.scala
@@ -12,7 +12,7 @@ import tsec.common.ByteEV
 
 import scala.concurrent.duration._
 
-class CookieAuthenticatorTests extends RequestAuthenticatorSpec[AuthenticatedCookie[?, Int]] {
+class CookieAuthenticatorTests extends RequestAuthenticatorSpec {
 
   private val cookieName                     = "hi"
   implicit def cookiebackingStore[A: MacTag] = dummyBackingStore[IO, UUID, AuthenticatedCookie[A, Int]](_.id)
@@ -20,7 +20,7 @@ class CookieAuthenticatorTests extends RequestAuthenticatorSpec[AuthenticatedCoo
   def genAuthenticator[A: MacTag: ByteEV](
       implicit keyGenerator: MacKeyGenerator[A],
       store: BackingStore[IO, UUID, AuthenticatedCookie[A, Int]]
-  ): AuthSpecTester[A, AuthenticatedCookie[?, Int]] = {
+  ): AuthSpecTester[AuthenticatedCookie[A, Int]] = {
     val dummyStore = dummyBackingStore[IO, Int, DummyUser](_.id)
     val authenticator = CookieAuthenticator[IO, A, Int, DummyUser](
       TSecCookieSettings(cookieName, false, expiryDuration = 10.minutes, maxIdle = Some(10.minutes)),
@@ -28,7 +28,7 @@ class CookieAuthenticatorTests extends RequestAuthenticatorSpec[AuthenticatedCoo
       dummyStore,
       keyGenerator.generateKeyUnsafe(),
     )
-    new AuthSpecTester[A, AuthenticatedCookie[?, Int]](authenticator, dummyStore) {
+    new AuthSpecTester[AuthenticatedCookie[A, Int]](authenticator, dummyStore) {
 
       def embedInRequest(request: Request[IO], authenticator: AuthenticatedCookie[A, Int]): Request[IO] =
         request.addCookie(authenticator.toCookie)
@@ -56,14 +56,20 @@ class CookieAuthenticatorTests extends RequestAuthenticatorSpec[AuthenticatedCoo
     }
   }
 
-  AuthenticatorTest[HMACSHA1]("HMACSHA1 Authenticator", genAuthenticator[HMACSHA1])
-  AuthenticatorTest[HMACSHA256]("HMACSHA256 Authenticator", genAuthenticator[HMACSHA256])
-  AuthenticatorTest[HMACSHA384]("HMACSHA384 Authenticator", genAuthenticator[HMACSHA384])
-  AuthenticatorTest[HMACSHA512]("HMACSHA512 Authenticator", genAuthenticator[HMACSHA512])
+  def CookieAuthTest[A: MacTag: ByteEV](string: String, auth: AuthSpecTester[AuthenticatedCookie[A, Int]]) =
+    AuthenticatorTest[AuthenticatedCookie[A, Int]](string, auth)
 
-  RequestAuthTests[HMACSHA1]("HMACSHA1 Authenticator", genAuthenticator[HMACSHA1])
-  RequestAuthTests[HMACSHA256]("HMACSHA256 Authenticator", genAuthenticator[HMACSHA256])
-  RequestAuthTests[HMACSHA384]("HMACSHA384 Authenticator", genAuthenticator[HMACSHA384])
-  RequestAuthTests[HMACSHA512]("HMACSHA512 Authenticator", genAuthenticator[HMACSHA512])
+  def CookieReqTest[A: MacTag: ByteEV](string: String, auth: AuthSpecTester[AuthenticatedCookie[A, Int]]) =
+    RequestAuthTests[AuthenticatedCookie[A, Int]](string, auth)
+
+  CookieAuthTest[HMACSHA1]("HMACSHA1 Authenticator", genAuthenticator[HMACSHA1])
+  CookieAuthTest[HMACSHA256]("HMACSHA256 Authenticator", genAuthenticator[HMACSHA256])
+  CookieAuthTest[HMACSHA384]("HMACSHA384 Authenticator", genAuthenticator[HMACSHA384])
+  CookieAuthTest[HMACSHA512]("HMACSHA512 Authenticator", genAuthenticator[HMACSHA512])
+
+  CookieReqTest[HMACSHA1]("HMACSHA1 Authenticator", genAuthenticator[HMACSHA1])
+  CookieReqTest[HMACSHA256]("HMACSHA256 Authenticator", genAuthenticator[HMACSHA256])
+  CookieReqTest[HMACSHA384]("HMACSHA384 Authenticator", genAuthenticator[HMACSHA384])
+  CookieReqTest[HMACSHA512]("HMACSHA512 Authenticator", genAuthenticator[HMACSHA512])
 
 }

--- a/tsec-http4s/src/test/scala/tsec/authentication/EncryptedCookieAuthenticatorSpec.scala
+++ b/tsec-http4s/src/test/scala/tsec/authentication/EncryptedCookieAuthenticatorSpec.scala
@@ -12,7 +12,7 @@ import io.circe.parser.decode
 import io.circe.generic.auto._
 import scala.concurrent.duration._
 
-class EncryptedCookieAuthenticatorSpec extends RequestAuthenticatorSpec[AuthEncryptedCookie[?, Int]] {
+class EncryptedCookieAuthenticatorSpec extends RequestAuthenticatorSpec {
 
   private val cookieName = "hi"
 
@@ -22,7 +22,7 @@ class EncryptedCookieAuthenticatorSpec extends RequestAuthenticatorSpec[AuthEncr
       implicit authEncryptor: AuthEncryptor[A],
       keygen: CipherKeyGen[A],
       store: BackingStore[IO, UUID, AuthEncryptedCookie[A, Int]]
-  ): AuthSpecTester[A, AuthEncryptedCookie[?, Int]] = {
+  ): AuthSpecTester[AuthEncryptedCookie[A, Int]] = {
     val dummyStore = dummyBackingStore[IO, Int, DummyUser](_.id)
     val authenticator = EncryptedCookieAuthenticator.withBackingStore[IO, A, Int, DummyUser](
       TSecCookieSettings(cookieName, false, expiryDuration = 10.minutes, maxIdle = Some(10.minutes)),
@@ -30,11 +30,10 @@ class EncryptedCookieAuthenticatorSpec extends RequestAuthenticatorSpec[AuthEncr
       dummyStore,
       keygen.generateKeyUnsafe()
     )
-    new AuthSpecTester[A, AuthEncryptedCookie[?, Int]](authenticator, dummyStore) {
+    new AuthSpecTester[AuthEncryptedCookie[A, Int]](authenticator, dummyStore) {
 
       def embedInRequest(request: Request[IO], authenticator: AuthEncryptedCookie[A, Int]): Request[IO] =
         request.addCookie(authenticator.toCookie)
-
 
       def expireAuthenticator(b: AuthEncryptedCookie[A, Int]): OptionT[IO, AuthEncryptedCookie[A, Int]] = {
         val now     = Instant.now()
@@ -63,7 +62,7 @@ class EncryptedCookieAuthenticatorSpec extends RequestAuthenticatorSpec[AuthEncr
   def genStatelessAuthenticator[A](
       implicit authEncryptor: AuthEncryptor[A],
       keygen: CipherKeyGen[A]
-  ): AuthSpecTester[A, AuthEncryptedCookie[?, Int]] = {
+  ): AuthSpecTester[AuthEncryptedCookie[A, Int]] = {
     val dummyStore = dummyBackingStore[IO, Int, DummyUser](_.id)
     val secretKey  = keygen.generateKeyUnsafe()
     val authenticator = EncryptedCookieAuthenticator.stateless[IO, A, Int, DummyUser](
@@ -71,7 +70,7 @@ class EncryptedCookieAuthenticatorSpec extends RequestAuthenticatorSpec[AuthEncr
       dummyStore,
       secretKey
     )
-    new AuthSpecTester[A, AuthEncryptedCookie[?, Int]](authenticator, dummyStore) {
+    new AuthSpecTester[AuthEncryptedCookie[A, Int]](authenticator, dummyStore) {
 
       def embedInRequest(request: Request[IO], authenticator: AuthEncryptedCookie[A, Int]): Request[IO] =
         request.addCookie(authenticator.toCookie)

--- a/tsec-http4s/src/test/scala/tsec/authentication/EncryptedCookieAuthenticatorTests.scala
+++ b/tsec-http4s/src/test/scala/tsec/authentication/EncryptedCookieAuthenticatorTests.scala
@@ -4,17 +4,17 @@ import tsec.cipher.symmetric.imports._
 
 class EncryptedCookieAuthenticatorTests extends EncryptedCookieAuthenticatorSpec {
 
-  AuthenticatorTest[AES128]("AES128 Authenticator w\\ backing store", genStatefulAuthenticator[AES128])
-  AuthenticatorTest[AES192]("AES192 Authenticator w\\ backing store", genStatefulAuthenticator[AES192])
-  AuthenticatorTest[AES256]("AES256 Authenticator w\\ backing store", genStatefulAuthenticator[AES256])
-  AuthenticatorTest[AES128]("AES128 Authenticator stateless", genStatelessAuthenticator[AES128])
-  AuthenticatorTest[AES192]("AES192 Authenticator stateless", genStatelessAuthenticator[AES192])
-  AuthenticatorTest[AES256]("AES256 Authenticator stateless", genStatelessAuthenticator[AES256])
+  AuthenticatorTest[AuthEncryptedCookie[AES128, Int]]("AES128 Authenticator w\\ backing store", genStatefulAuthenticator[AES128])
+  AuthenticatorTest[AuthEncryptedCookie[AES192, Int]]("AES192 Authenticator w\\ backing store", genStatefulAuthenticator[AES192])
+  AuthenticatorTest[AuthEncryptedCookie[AES256, Int]]("AES256 Authenticator w\\ backing store", genStatefulAuthenticator[AES256])
+  AuthenticatorTest[AuthEncryptedCookie[AES128, Int]]("AES128 Authenticator stateless", genStatelessAuthenticator[AES128])
+  AuthenticatorTest[AuthEncryptedCookie[AES192, Int]]("AES192 Authenticator stateless", genStatelessAuthenticator[AES192])
+  AuthenticatorTest[AuthEncryptedCookie[AES256, Int]]("AES256 Authenticator stateless", genStatelessAuthenticator[AES256])
 
-  RequestAuthTests[AES128]("AES128 Authenticator w\\ backing store", genStatefulAuthenticator[AES128])
-  RequestAuthTests[AES192]("AES192 Authenticator w\\ backing store", genStatefulAuthenticator[AES192])
-  RequestAuthTests[AES256]("AES256 Authenticator w\\ backing store", genStatefulAuthenticator[AES256])
-  RequestAuthTests[AES128]("AES128 Authenticator stateless", genStatelessAuthenticator[AES128])
-  RequestAuthTests[AES192]("AES192 Authenticator stateless", genStatelessAuthenticator[AES192])
-  RequestAuthTests[AES256]("AES256 Authenticator stateless", genStatelessAuthenticator[AES256])
+  RequestAuthTests[AuthEncryptedCookie[AES128, Int]]("AES128 Authenticator w\\ backing store", genStatefulAuthenticator[AES128])
+  RequestAuthTests[AuthEncryptedCookie[AES192, Int]]("AES192 Authenticator w\\ backing store", genStatefulAuthenticator[AES192])
+  RequestAuthTests[AuthEncryptedCookie[AES256, Int]]("AES256 Authenticator w\\ backing store", genStatefulAuthenticator[AES256])
+  RequestAuthTests[AuthEncryptedCookie[AES128, Int]]("AES128 Authenticator stateless", genStatelessAuthenticator[AES128])
+  RequestAuthTests[AuthEncryptedCookie[AES192, Int]]("AES192 Authenticator stateless", genStatelessAuthenticator[AES192])
+  RequestAuthTests[AuthEncryptedCookie[AES256, Int]]("AES256 Authenticator stateless", genStatelessAuthenticator[AES256])
 }

--- a/tsec-http4s/src/test/scala/tsec/authentication/EncryptedCookieAuthenticatorTests.scala
+++ b/tsec-http4s/src/test/scala/tsec/authentication/EncryptedCookieAuthenticatorTests.scala
@@ -11,10 +11,10 @@ class EncryptedCookieAuthenticatorTests extends EncryptedCookieAuthenticatorSpec
   AuthenticatorTest[AuthEncryptedCookie[AES192, Int]]("AES192 Authenticator stateless", genStatelessAuthenticator[AES192])
   AuthenticatorTest[AuthEncryptedCookie[AES256, Int]]("AES256 Authenticator stateless", genStatelessAuthenticator[AES256])
 
-  RequestAuthTests[AuthEncryptedCookie[AES128, Int]]("AES128 Authenticator w\\ backing store", genStatefulAuthenticator[AES128])
-  RequestAuthTests[AuthEncryptedCookie[AES192, Int]]("AES192 Authenticator w\\ backing store", genStatefulAuthenticator[AES192])
-  RequestAuthTests[AuthEncryptedCookie[AES256, Int]]("AES256 Authenticator w\\ backing store", genStatefulAuthenticator[AES256])
-  RequestAuthTests[AuthEncryptedCookie[AES128, Int]]("AES128 Authenticator stateless", genStatelessAuthenticator[AES128])
-  RequestAuthTests[AuthEncryptedCookie[AES192, Int]]("AES192 Authenticator stateless", genStatelessAuthenticator[AES192])
-  RequestAuthTests[AuthEncryptedCookie[AES256, Int]]("AES256 Authenticator stateless", genStatelessAuthenticator[AES256])
+  requestAuthTests[AuthEncryptedCookie[AES128, Int]]("AES128 Authenticator w\\ backing store", genStatefulAuthenticator[AES128])
+  requestAuthTests[AuthEncryptedCookie[AES192, Int]]("AES192 Authenticator w\\ backing store", genStatefulAuthenticator[AES192])
+  requestAuthTests[AuthEncryptedCookie[AES256, Int]]("AES256 Authenticator w\\ backing store", genStatefulAuthenticator[AES256])
+  requestAuthTests[AuthEncryptedCookie[AES128, Int]]("AES128 Authenticator stateless", genStatelessAuthenticator[AES128])
+  requestAuthTests[AuthEncryptedCookie[AES192, Int]]("AES192 Authenticator stateless", genStatelessAuthenticator[AES192])
+  requestAuthTests[AuthEncryptedCookie[AES256, Int]]("AES256 Authenticator stateless", genStatelessAuthenticator[AES256])
 }

--- a/tsec-http4s/src/test/scala/tsec/authentication/JWTAuthenticatorSpec.scala
+++ b/tsec-http4s/src/test/scala/tsec/authentication/JWTAuthenticatorSpec.scala
@@ -9,12 +9,12 @@ import org.http4s.{Header, HttpDate, Request}
 import io.circe.syntax._
 import tsec.authentication.JWTAuthenticator.JWTInternal
 import tsec.cipher.symmetric.imports.{CipherKeyGen, Encryptor}
-import tsec.common.ByteEV
+import tsec.common.{ByteEV, SecureRandomId}
 import tsec.jws.mac.{JWSMacCV, JWTMac, JWTMacM}
 import tsec.jwt.algorithms.JWTMacAlgo
 import tsec.mac.imports.{MacKeyGenerator, MacTag}
-
 import io.circe.generic.auto._
+
 import scala.concurrent.duration._
 
 class JWTAuthenticatorSpec extends RequestAuthenticatorSpec[JWTMac] {
@@ -26,18 +26,19 @@ class JWTAuthenticatorSpec extends RequestAuthenticatorSpec[JWTMac] {
       Some(10.minutes)
     )
 
-  implicit def backingStore[A]: BackingStore[IO, UUID, JWTMac[A]] = dummyBackingStore[IO, UUID, JWTMac[A]](_.id)
+  implicit def backingStore[A]: BackingStore[IO, SecureRandomId, JWTMac[A]] =
+    dummyBackingStore[IO, SecureRandomId, JWTMac[A]](s => SecureRandomId.coerce(s.id))
 
   def genStatefulAuthenticator[A: ByteEV: JWTMacAlgo: MacTag, E](
       implicit cv: JWSMacCV[IO, A],
       enc: Encryptor[E],
       eKeyGen: CipherKeyGen[E],
       macKeyGen: MacKeyGenerator[A],
-      store: BackingStore[IO, UUID, JWTMac[A]]
+      store: BackingStore[IO, SecureRandomId, JWTMac[A]]
   ): AuthSpecTester[A, JWTMac] = {
     val dummyStore = dummyBackingStore[IO, Int, DummyUser](_.id)
-    val macKey    = macKeyGen.generateKeyUnsafe()
-    val cryptoKey = eKeyGen.generateKeyUnsafe()
+    val macKey     = macKeyGen.generateKeyUnsafe()
+    val cryptoKey  = eKeyGen.generateKeyUnsafe()
     val auth = JWTAuthenticator.withBackingStore[IO, A, Int, DummyUser, E](
       settings,
       store,
@@ -72,8 +73,6 @@ class JWTAuthenticatorSpec extends RequestAuthenticatorSpec[JWTMac] {
           _ <- OptionT.liftF(store.update(newToken))
         } yield newToken
 
-
-
       def wrongKeyAuthenticator: OptionT[IO, JWTMac[A]] =
         JWTAuthenticator
           .withBackingStore[IO, A, Int, DummyUser, E](
@@ -94,8 +93,8 @@ class JWTAuthenticatorSpec extends RequestAuthenticatorSpec[JWTMac] {
       macKeyGen: MacKeyGenerator[A]
   ): AuthSpecTester[A, JWTMac] = {
     val dummyStore = dummyBackingStore[IO, Int, DummyUser](_.id)
-    val macKey    = macKeyGen.generateKeyUnsafe()
-    val cryptoKey = eKeyGen.generateKeyUnsafe()
+    val macKey     = macKeyGen.generateKeyUnsafe()
+    val cryptoKey  = eKeyGen.generateKeyUnsafe()
     val auth = JWTAuthenticator.stateless[IO, A, Int, DummyUser, E](
       settings,
       dummyStore,
@@ -126,7 +125,6 @@ class JWTAuthenticatorSpec extends RequestAuthenticatorSpec[JWTMac] {
               .build[IO, A](b.body.copy(custom = Some(newInternal.asJson)), macKey)
           }
         } yield newToken
-
 
       def wrongKeyAuthenticator: OptionT[IO, JWTMac[A]] =
         JWTAuthenticator

--- a/tsec-http4s/src/test/scala/tsec/authentication/JWTAuthenticatorSpec.scala
+++ b/tsec-http4s/src/test/scala/tsec/authentication/JWTAuthenticatorSpec.scala
@@ -17,7 +17,7 @@ import io.circe.generic.auto._
 
 import scala.concurrent.duration._
 
-class JWTAuthenticatorSpec extends RequestAuthenticatorSpec[JWTMac] {
+class JWTAuthenticatorSpec extends RequestAuthenticatorSpec {
 
   private val settings =
     TSecJWTSettings(
@@ -35,7 +35,7 @@ class JWTAuthenticatorSpec extends RequestAuthenticatorSpec[JWTMac] {
       eKeyGen: CipherKeyGen[E],
       macKeyGen: MacKeyGenerator[A],
       store: BackingStore[IO, SecureRandomId, JWTMac[A]]
-  ): AuthSpecTester[A, JWTMac] = {
+  ): AuthSpecTester[JWTMac[A]] = {
     val dummyStore = dummyBackingStore[IO, Int, DummyUser](_.id)
     val macKey     = macKeyGen.generateKeyUnsafe()
     val cryptoKey  = eKeyGen.generateKeyUnsafe()
@@ -46,7 +46,7 @@ class JWTAuthenticatorSpec extends RequestAuthenticatorSpec[JWTMac] {
       macKey,
       cryptoKey
     )
-    new AuthSpecTester[A, JWTMac](auth, dummyStore) {
+    new AuthSpecTester[JWTMac[A]](auth, dummyStore) {
 
       def embedInRequest(request: Request[IO], authenticator: JWTMac[A]): Request[IO] =
         request.withHeaders(
@@ -91,7 +91,7 @@ class JWTAuthenticatorSpec extends RequestAuthenticatorSpec[JWTMac] {
       enc: Encryptor[E],
       eKeyGen: CipherKeyGen[E],
       macKeyGen: MacKeyGenerator[A]
-  ): AuthSpecTester[A, JWTMac] = {
+  ): AuthSpecTester[JWTMac[A]] = {
     val dummyStore = dummyBackingStore[IO, Int, DummyUser](_.id)
     val macKey     = macKeyGen.generateKeyUnsafe()
     val cryptoKey  = eKeyGen.generateKeyUnsafe()
@@ -101,7 +101,7 @@ class JWTAuthenticatorSpec extends RequestAuthenticatorSpec[JWTMac] {
       macKey,
       cryptoKey
     )
-    new AuthSpecTester[A, JWTMac](auth, dummyStore) {
+    new AuthSpecTester[JWTMac[A]](auth, dummyStore) {
 
       def embedInRequest(request: Request[IO], authenticator: JWTMac[A]): Request[IO] =
         request.withHeaders(

--- a/tsec-http4s/src/test/scala/tsec/authentication/JWTAuthenticatorTests.scala
+++ b/tsec-http4s/src/test/scala/tsec/authentication/JWTAuthenticatorTests.scala
@@ -16,10 +16,10 @@ class JWTAuthenticatorTests extends JWTAuthenticatorSpec {
   AuthenticatorTest[JWTMac[HMACSHA384]]("HMACSHA384 JWT Stateless Authenticator", genStateless[HMACSHA384, AES128])
   AuthenticatorTest[JWTMac[HMACSHA512]]("HMACSHA512 JWT Stateless Authenticator", genStateless[HMACSHA512, AES128])
 
-  RequestAuthTests[JWTMac[HMACSHA256]]("HMACSHA256 JWT Stateful Authenticator", genStatefulAuthenticator[HMACSHA256, AES128])
-  RequestAuthTests[JWTMac[HMACSHA384]]("HMACSHA384 JWT Stateful Authenticator", genStatefulAuthenticator[HMACSHA384, AES128])
-  RequestAuthTests[JWTMac[HMACSHA512]]("HMACSHA512 JWT Stateful Authenticator", genStatefulAuthenticator[HMACSHA512, AES128])
-  RequestAuthTests[JWTMac[HMACSHA256]]("HMACSHA256 JWT Stateless Authenticator", genStateless[HMACSHA256, AES128])
-  RequestAuthTests[JWTMac[HMACSHA384]]("HMACSHA384 JWT Stateless Authenticator", genStateless[HMACSHA384, AES128])
-  RequestAuthTests[JWTMac[HMACSHA512]]("HMACSHA512 JWT Stateless Authenticator", genStateless[HMACSHA512, AES128])
+  requestAuthTests[JWTMac[HMACSHA256]]("HMACSHA256 JWT Stateful Authenticator", genStatefulAuthenticator[HMACSHA256, AES128])
+  requestAuthTests[JWTMac[HMACSHA384]]("HMACSHA384 JWT Stateful Authenticator", genStatefulAuthenticator[HMACSHA384, AES128])
+  requestAuthTests[JWTMac[HMACSHA512]]("HMACSHA512 JWT Stateful Authenticator", genStatefulAuthenticator[HMACSHA512, AES128])
+  requestAuthTests[JWTMac[HMACSHA256]]("HMACSHA256 JWT Stateless Authenticator", genStateless[HMACSHA256, AES128])
+  requestAuthTests[JWTMac[HMACSHA384]]("HMACSHA384 JWT Stateless Authenticator", genStateless[HMACSHA384, AES128])
+  requestAuthTests[JWTMac[HMACSHA512]]("HMACSHA512 JWT Stateless Authenticator", genStateless[HMACSHA512, AES128])
 }

--- a/tsec-http4s/src/test/scala/tsec/authentication/JWTAuthenticatorTests.scala
+++ b/tsec-http4s/src/test/scala/tsec/authentication/JWTAuthenticatorTests.scala
@@ -9,17 +9,17 @@ import tsec.mac.imports._
 
 class JWTAuthenticatorTests extends JWTAuthenticatorSpec {
 
-  AuthenticatorTest[HMACSHA256]("HMACSHA256 JWT Stateful Authenticator", genStatefulAuthenticator[HMACSHA256, AES128])
-  AuthenticatorTest[HMACSHA384]("HMACSHA384 JWT Stateful Authenticator", genStatefulAuthenticator[HMACSHA384, AES128])
-  AuthenticatorTest[HMACSHA512]("HMACSHA512 JWT Stateful Authenticator", genStatefulAuthenticator[HMACSHA512, AES128])
-  AuthenticatorTest[HMACSHA256]("HMACSHA256 JWT Stateless Authenticator", genStateless[HMACSHA256, AES128])
-  AuthenticatorTest[HMACSHA384]("HMACSHA384 JWT Stateless Authenticator", genStateless[HMACSHA384, AES128])
-  AuthenticatorTest[HMACSHA512]("HMACSHA512 JWT Stateless Authenticator", genStateless[HMACSHA512, AES128])
+  AuthenticatorTest[JWTMac[HMACSHA256]]("HMACSHA256 JWT Stateful Authenticator", genStatefulAuthenticator[HMACSHA256, AES128])
+  AuthenticatorTest[JWTMac[HMACSHA384]]("HMACSHA384 JWT Stateful Authenticator", genStatefulAuthenticator[HMACSHA384, AES128])
+  AuthenticatorTest[JWTMac[HMACSHA512]]("HMACSHA512 JWT Stateful Authenticator", genStatefulAuthenticator[HMACSHA512, AES128])
+  AuthenticatorTest[JWTMac[HMACSHA256]]("HMACSHA256 JWT Stateless Authenticator", genStateless[HMACSHA256, AES128])
+  AuthenticatorTest[JWTMac[HMACSHA384]]("HMACSHA384 JWT Stateless Authenticator", genStateless[HMACSHA384, AES128])
+  AuthenticatorTest[JWTMac[HMACSHA512]]("HMACSHA512 JWT Stateless Authenticator", genStateless[HMACSHA512, AES128])
 
-  RequestAuthTests[HMACSHA256]("HMACSHA256 JWT Stateful Authenticator", genStatefulAuthenticator[HMACSHA256, AES128])
-  RequestAuthTests[HMACSHA384]("HMACSHA384 JWT Stateful Authenticator", genStatefulAuthenticator[HMACSHA384, AES128])
-  RequestAuthTests[HMACSHA512]("HMACSHA512 JWT Stateful Authenticator", genStatefulAuthenticator[HMACSHA512, AES128])
-  RequestAuthTests[HMACSHA256]("HMACSHA256 JWT Stateless Authenticator", genStateless[HMACSHA256, AES128])
-  RequestAuthTests[HMACSHA384]("HMACSHA384 JWT Stateless Authenticator", genStateless[HMACSHA384, AES128])
-  RequestAuthTests[HMACSHA512]("HMACSHA512 JWT Stateless Authenticator", genStateless[HMACSHA512, AES128])
+  RequestAuthTests[JWTMac[HMACSHA256]]("HMACSHA256 JWT Stateful Authenticator", genStatefulAuthenticator[HMACSHA256, AES128])
+  RequestAuthTests[JWTMac[HMACSHA384]]("HMACSHA384 JWT Stateful Authenticator", genStatefulAuthenticator[HMACSHA384, AES128])
+  RequestAuthTests[JWTMac[HMACSHA512]]("HMACSHA512 JWT Stateful Authenticator", genStatefulAuthenticator[HMACSHA512, AES128])
+  RequestAuthTests[JWTMac[HMACSHA256]]("HMACSHA256 JWT Stateless Authenticator", genStateless[HMACSHA256, AES128])
+  RequestAuthTests[JWTMac[HMACSHA384]]("HMACSHA384 JWT Stateless Authenticator", genStateless[HMACSHA384, AES128])
+  RequestAuthTests[JWTMac[HMACSHA512]]("HMACSHA512 JWT Stateless Authenticator", genStateless[HMACSHA512, AES128])
 }

--- a/tsec-http4s/src/test/scala/tsec/authentication/RequestAuthenticatorSpec.scala
+++ b/tsec-http4s/src/test/scala/tsec/authentication/RequestAuthenticatorSpec.scala
@@ -10,15 +10,15 @@ import io.circe.syntax._
 import io.circe.generic.auto._
 import tsec.authorization.BasicRBAC
 
-class RequestAuthenticatorSpec[B[_]] extends AuthenticatorSpec[B] {
+class RequestAuthenticatorSpec extends AuthenticatorSpec  {
 
-  def RequestAuthTests[A](title: String, authSpec: AuthSpecTester[A, B]) {
+  def RequestAuthTests[A](title: String, authSpec: AuthSpecTester[A]) {
 
     behavior of "SecuredRequests: " + title
 
     val dummyBob = DummyUser(0)
 
-    val requestAuth: SecuredRequestHandler[IO, A, Int, DummyUser, B] = SecuredRequestHandler(authSpec.auth)
+    val requestAuth: SecuredRequestHandler[IO, Int, DummyUser, A] = SecuredRequestHandler(authSpec.auth)
 
     //Add bob to the db
     authSpec.dummyStore.put(dummyBob).unsafeRunSync()

--- a/tsec-http4s/src/test/scala/tsec/authentication/RequestAuthenticatorSpec.scala
+++ b/tsec-http4s/src/test/scala/tsec/authentication/RequestAuthenticatorSpec.scala
@@ -10,7 +10,7 @@ import io.circe.syntax._
 import io.circe.generic.auto._
 import tsec.authorization.BasicRBAC
 
-class RequestAuthenticatorSpec extends AuthenticatorSpec  {
+class RequestAuthenticatorSpec extends AuthenticatorSpec {
 
   def requestAuthTests[A](title: String, authSpec: AuthSpecTester[A]) {
 
@@ -23,8 +23,8 @@ class RequestAuthenticatorSpec extends AuthenticatorSpec  {
     //Add bob to the db
     authSpec.dummyStore.put(dummyBob).unsafeRunSync()
 
-    val onlyAdmins = BasicRBAC[IO, DummyUser, DummyRole](DummyRole.Admin)
-    val everyone   = BasicRBAC.all[IO, DummyUser, DummyRole]
+    val onlyAdmins = BasicRBAC[IO, DummyRole, DummyUser](DummyRole.Admin)
+    val everyone   = BasicRBAC.all[IO, DummyRole, DummyUser]
 
     val testService: HttpService[IO] = requestAuth {
       case request @ GET -> Root / "api" asAuthed hi =>

--- a/tsec-http4s/src/test/scala/tsec/authentication/RequestAuthenticatorSpec.scala
+++ b/tsec-http4s/src/test/scala/tsec/authentication/RequestAuthenticatorSpec.scala
@@ -12,7 +12,7 @@ import tsec.authorization.BasicRBAC
 
 class RequestAuthenticatorSpec extends AuthenticatorSpec  {
 
-  def RequestAuthTests[A](title: String, authSpec: AuthSpecTester[A]) {
+  def requestAuthTests[A](title: String, authSpec: AuthSpecTester[A]) {
 
     behavior of "SecuredRequests: " + title
 

--- a/tsec-http4s/src/test/scala/tsec/authentication/SignedCookieAuthenticatorTests.scala
+++ b/tsec-http4s/src/test/scala/tsec/authentication/SignedCookieAuthenticatorTests.scala
@@ -12,7 +12,7 @@ import tsec.common.ByteEV
 
 import scala.concurrent.duration._
 
-class CookieAuthenticatorTests extends RequestAuthenticatorSpec {
+class SignedCookieAuthenticatorTests extends RequestAuthenticatorSpec {
 
   private val cookieName                     = "hi"
   implicit def cookiebackingStore[A: MacTag] = dummyBackingStore[IO, UUID, AuthenticatedCookie[A, Int]](_.id)


### PR DESCRIPTION
Breaking: 
* JWTClaims `jwtId` changed from UUID to String, so we can use `SecureRandomId`
* TaggedByteSyntax changed from `toArray` to `asByteArray`
* `Alg` type parameter removed from authenticator. now infers type nicely.
* backing store signature changed.
* JWTMacPure abstracted out into `F: Sync` instead of just IO @aeons 
* Authorization classes got a revamp
* Authorization classes are now all tested! None of the logic changed, but it's good to double-check.
* Signatures in Authorization classes changed to be consistent with `Role, User`

New:
* CSRF middleware and tests
* `SecureRandomId` and `SecureRandomIdGenerator`.
* BearerToken authenticator and tests
* Fixed SecureRandom reseeding.
* Authorization monoid instnace