### PR TITLE
Final auth-changes for 0.0.1-M4

### DIFF
--- a/examples/src/main/scala/Http4sAuthExamples.scala
+++ b/examples/src/main/scala/Http4sAuthExamples.scala
@@ -43,12 +43,12 @@ object Http4sAuthExamples {
   In our example, we will demonstrate how to use SimpleAuthEnum, as well as
   Role based authorization
    */
-  sealed abstract class Role(val roleRepr: String)
+  sealed abstract case class Role(roleRepr: String)
   object Role extends SimpleAuthEnum[Role, String] {
-    implicit case object Administrator extends Role("Administrator")
-    implicit case object Customer      extends Role("User")
-    implicit case object Seller        extends Role("Seller")
-    implicit case object CorruptedData extends Role("corrupted")
+    implicit object Administrator extends Role("Administrator")
+    implicit object Customer      extends Role("User")
+    implicit object Seller        extends Role("Seller")
+    implicit object CorruptedData extends Role("corrupted")
 
     implicit val E: Eq[Role]      = Eq.fromUniversalEquals[Role]
     val getRepr: (Role) => String = _.roleRepr
@@ -106,8 +106,8 @@ object Http4sAuthExamples {
   val Auth =
     SecuredRequestHandler(encryptedCookieAuth)
 
-  val onlyAdmins      = BasicRBAC[IO, Role, User](Role.Administrator, Role.Customer)
-  val adminsAndSeller = BasicRBAC[IO, Role, User](Role.Administrator, Role.Seller)
+  val onlyAdmins      = BasicRBAC[IO, Role, User, AuthEncryptedCookie[AES128, Int]](Role.Administrator, Role.Customer)
+  val adminsAndSeller = BasicRBAC[IO, Role, User, AuthEncryptedCookie[AES128, Int]](Role.Administrator, Role.Seller)
 
   /*
   Now from here, if want want to create services, we simply use the following
@@ -122,7 +122,7 @@ object Http4sAuthExamples {
       2. The Authenticator (i.e token)
       3. The identity (i.e in this case, User)
        */
-      val r: SecuredRequest[IO, AuthEncryptedCookie[AES128, Int], User] = request
+      val r: SecuredRequest[IO, User, AuthEncryptedCookie[AES128, Int]] = request
       Ok()
   }
 

--- a/tsec-http4s/src/main/scala/tsec/authentication/Authenticator.scala
+++ b/tsec-http4s/src/main/scala/tsec/authentication/Authenticator.scala
@@ -10,6 +10,7 @@ import org.http4s.{Request, Response}
   *
   * @tparam I The Identifier type
   * @tparam V The value type, i.e user, or possibly only partial information
+  * @tparam Authenticator the type of authenticator
   */
 trait Authenticator[F[_], I, V, Authenticator] {
 
@@ -17,7 +18,7 @@ trait Authenticator[F[_], I, V, Authenticator] {
     * @param request
     * @return
     */
-  def extractAndValidate(request: Request[F]): OptionT[F, SecuredRequest[F, Authenticator, V]]
+  def extractAndValidate(request: Request[F]): OptionT[F, SecuredRequest[F, V, Authenticator]]
 
   /** Create an authenticator from an identifier.
     * @param body

--- a/tsec-http4s/src/main/scala/tsec/authentication/package.scala
+++ b/tsec-http4s/src/main/scala/tsec/authentication/package.scala
@@ -52,15 +52,15 @@ package object authentication {
     Middleware[OptionT[F, ?], SecuredRequest[F, I, A], Response[F], Request[F], Response[F]]
 
   object TSecMiddleware {
-    def apply[F[_]: Monad, A, I](
-        authedStuff: Kleisli[OptionT[F, ?], Request[F], SecuredRequest[F, A, I]]
-    ): TSecMiddleware[F, A, I] =
+    def apply[F[_]: Monad, Ident, Auth](
+        authedStuff: Kleisli[OptionT[F, ?], Request[F], SecuredRequest[F, Ident, Auth]]
+    ): TSecMiddleware[F, Ident, Auth] =
       service => {
         service.compose(authedStuff)
       }
   }
 
-  type TSecAuthService[F[_], A, I] = Kleisli[OptionT[F, ?], SecuredRequest[F, A, I], Response[F]]
+  type TSecAuthService[F[_], Ident, A] = Kleisli[OptionT[F, ?], SecuredRequest[F, Ident, A], Response[F]]
 
   object TSecAuthService {
 
@@ -86,11 +86,11 @@ package object authentication {
 
     /** The empty service (all requests fallthrough).
       * @tparam F - Ignored
+      * @tparam Ident - Ignored
       * @tparam A - Ignored
-      * @tparam I - Ignored
       * @return
       */
-    def empty[F[_]: Applicative, A, I]: TSecAuthService[F, A, I] =
+    def empty[F[_]: Applicative, Ident, A]: TSecAuthService[F, Ident, A] =
       Kleisli.lift(OptionT.none)
   }
 

--- a/tsec-http4s/src/main/scala/tsec/authorization/BasicRBAC.scala
+++ b/tsec-http4s/src/main/scala/tsec/authorization/BasicRBAC.scala
@@ -7,15 +7,15 @@ import cats.syntax.functor._
 
 import scala.reflect.ClassTag
 
-sealed abstract case class BasicRBAC[F[_], R, U](authorized: AuthGroup[R])(
+sealed abstract case class BasicRBAC[F[_], R, U, Auth](authorized: AuthGroup[R])(
     implicit role: AuthorizationInfo[F, R, U],
     enum: SimpleAuthEnum[R, String],
     F: MonadError[F, Throwable]
-) extends Authorization[F, U] {
+) extends Authorization[F, U, Auth] {
 
-  def isAuthorized[Auth](
-      toAuth: authentication.SecuredRequest[F, Auth, U]
-  ): OptionT[F, authentication.SecuredRequest[F, Auth, U]] =
+  def isAuthorized(
+      toAuth: authentication.SecuredRequest[F, U, Auth]
+  ): OptionT[F, authentication.SecuredRequest[F, U, Auth]] =
     OptionT {
       role.fetchInfo(toAuth.identity).map { extractedRole =>
         if (enum.contains(extractedRole) && authorized.contains(extractedRole))
@@ -27,23 +27,23 @@ sealed abstract case class BasicRBAC[F[_], R, U](authorized: AuthGroup[R])(
 }
 
 object BasicRBAC {
-  def apply[F[_], R: ClassTag, U](roles: R*)(
+  def apply[F[_], R: ClassTag, U, Auth](roles: R*)(
       implicit enum: SimpleAuthEnum[R, String],
       role: AuthorizationInfo[F, R, U],
       F: MonadError[F, Throwable]
-  ): BasicRBAC[F, R, U] =
-    fromGroup[F, R, U](AuthGroup(roles: _*))
+  ): BasicRBAC[F, R, U, Auth] =
+    fromGroup[F, R, U, Auth](AuthGroup(roles: _*))
 
-  def fromGroup[F[_], R: ClassTag, U](valueSet: AuthGroup[R])(
+  def fromGroup[F[_], R: ClassTag, U, Auth](valueSet: AuthGroup[R])(
       implicit role: AuthorizationInfo[F, R, U],
       enum: SimpleAuthEnum[R, String],
       F: MonadError[F, Throwable]
-  ): BasicRBAC[F, R, U] = new BasicRBAC[F, R, U](valueSet) {}
+  ): BasicRBAC[F, R, U, Auth] = new BasicRBAC[F, R, U, Auth](valueSet) {}
 
-  def all[F[_], R: ClassTag, U](
+  def all[F[_], R: ClassTag, U, Auth](
       implicit enum: SimpleAuthEnum[R, String],
       role: AuthorizationInfo[F, R, U],
       F: MonadError[F, Throwable]
-  ): BasicRBAC[F, R, U] =
-    new BasicRBAC[F, R, U](enum.viewAll) {}
+  ): BasicRBAC[F, R, U, Auth] =
+    new BasicRBAC[F, R, U, Auth](enum.viewAll) {}
 }

--- a/tsec-http4s/src/main/scala/tsec/authorization/DynamicRBAC.scala
+++ b/tsec-http4s/src/main/scala/tsec/authorization/DynamicRBAC.scala
@@ -5,14 +5,14 @@ import cats.data.OptionT
 import tsec.authentication
 import cats.syntax.all._
 
-case class DynamicRBAC[F[_], Role, U](dynamic: DynamicAuthGroup[F, Role])(
+case class DynamicRBAC[F[_], Role, U, Auth](dynamic: DynamicAuthGroup[F, Role])(
     implicit authInfo: AuthorizationInfo[F, Role, U],
     enum: SimpleAuthEnum[Role, String],
     F: MonadError[F, Throwable]
-) extends Authorization[F, U] {
-  def isAuthorized[Auth](
-      toAuth: authentication.SecuredRequest[F, Auth, U]
-  ): OptionT[F, authentication.SecuredRequest[F, Auth, U]] =
+) extends Authorization[F, U, Auth] {
+  def isAuthorized(
+      toAuth: authentication.SecuredRequest[F, U, Auth]
+  ): OptionT[F, authentication.SecuredRequest[F, U, Auth]] =
     OptionT(for {
       info  <- authInfo.fetchInfo(toAuth.identity)
       group <- dynamic.fetchGroupInfo

--- a/tsec-http4s/src/main/scala/tsec/authorization/HierarchyAuth.scala
+++ b/tsec-http4s/src/main/scala/tsec/authorization/HierarchyAuth.scala
@@ -5,15 +5,15 @@ import cats.data.OptionT
 import tsec.authentication
 import cats.syntax.functor._
 
-sealed abstract case class HierarchyAuth[F[_], R, U](authLevel: R)(
+sealed abstract case class HierarchyAuth[F[_], R, U, Auth](authLevel: R)(
     implicit role: AuthorizationInfo[F, R, U],
     enum: SimpleAuthEnum[R, Int],
     F: MonadError[F, Throwable]
-) extends Authorization[F, U] {
+) extends Authorization[F, U, Auth] {
 
-  def isAuthorized[Auth](
-      toAuth: authentication.SecuredRequest[F, Auth, U]
-  ): OptionT[F, authentication.SecuredRequest[F, Auth, U]] =
+  def isAuthorized(
+      toAuth: authentication.SecuredRequest[F, U, Auth]
+  ): OptionT[F, authentication.SecuredRequest[F, U, Auth]] =
     OptionT {
       role.fetchInfo(toAuth.identity).map { authRole =>
         val intRepr = enum.getRepr(authRole)
@@ -27,13 +27,13 @@ sealed abstract case class HierarchyAuth[F[_], R, U](authLevel: R)(
 
 object HierarchyAuth {
 
-  def apply[F[_], U, R](auth: R)(
+  def apply[F[_], R, U, Auth](auth: R)(
       implicit role: AuthorizationInfo[F, R, U],
       e: SimpleAuthEnum[R, Int],
       F: MonadError[F, Throwable]
-  ): F[HierarchyAuth[F, R, U]] =
+  ): F[HierarchyAuth[F, R, U, Auth]] =
     if (e.getRepr(auth) < 0)
-      F.raiseError[HierarchyAuth[F, R, U]](InvalidAuthLevelError)
+      F.raiseError[HierarchyAuth[F, R, U, Auth]](InvalidAuthLevelError)
     else
-      F.pure(new HierarchyAuth[F, R, U](auth) {})
+      F.pure(new HierarchyAuth[F, R, U, Auth](auth) {})
 }

--- a/tsec-http4s/src/test/scala/tsec/authentication/EncryptedCookieAuthenticatorSpec.scala
+++ b/tsec-http4s/src/test/scala/tsec/authentication/EncryptedCookieAuthenticatorSpec.scala
@@ -24,7 +24,7 @@ class EncryptedCookieAuthenticatorSpec extends RequestAuthenticatorSpec {
       store: BackingStore[IO, UUID, AuthEncryptedCookie[A, Int]]
   ): AuthSpecTester[AuthEncryptedCookie[A, Int]] = {
     val dummyStore = dummyBackingStore[IO, Int, DummyUser](_.id)
-    val authenticator = EncryptedCookieAuthenticator.withBackingStore[IO, A, Int, DummyUser](
+    val authenticator = EncryptedCookieAuthenticator.withBackingStore[IO, Int, DummyUser, A](
       TSecCookieSettings(cookieName, false, expiryDuration = 10.minutes, maxIdle = Some(10.minutes)),
       store,
       dummyStore,
@@ -49,7 +49,7 @@ class EncryptedCookieAuthenticatorSpec extends RequestAuthenticatorSpec {
 
       def wrongKeyAuthenticator: OptionT[IO, AuthEncryptedCookie[A, Int]] =
         EncryptedCookieAuthenticator
-          .withBackingStore[IO, A, Int, DummyUser](
+          .withBackingStore[IO, Int, DummyUser, A](
             TSecCookieSettings(cookieName, false, expiryDuration = 10.minutes, maxIdle = Some(10.minutes)),
             store,
             dummyStore,
@@ -65,7 +65,7 @@ class EncryptedCookieAuthenticatorSpec extends RequestAuthenticatorSpec {
   ): AuthSpecTester[AuthEncryptedCookie[A, Int]] = {
     val dummyStore = dummyBackingStore[IO, Int, DummyUser](_.id)
     val secretKey  = keygen.generateKeyUnsafe()
-    val authenticator = EncryptedCookieAuthenticator.stateless[IO, A, Int, DummyUser](
+    val authenticator = EncryptedCookieAuthenticator.stateless[IO, Int, DummyUser, A](
       TSecCookieSettings(cookieName, false, expiryDuration = 10.minutes, maxIdle = Some(10.minutes)),
       dummyStore,
       secretKey
@@ -110,7 +110,7 @@ class EncryptedCookieAuthenticatorSpec extends RequestAuthenticatorSpec {
 
       def wrongKeyAuthenticator: OptionT[IO, AuthEncryptedCookie[A, Int]] =
         EncryptedCookieAuthenticator
-          .stateless[IO, A, Int, DummyUser](
+          .stateless[IO, Int, DummyUser, A](
             TSecCookieSettings(cookieName, false, expiryDuration = 10.minutes, maxIdle = Some(10.minutes)),
             dummyStore,
             keygen.generateKeyUnsafe()

--- a/tsec-http4s/src/test/scala/tsec/authentication/JWTAuthenticatorSpec.scala
+++ b/tsec-http4s/src/test/scala/tsec/authentication/JWTAuthenticatorSpec.scala
@@ -39,7 +39,7 @@ class JWTAuthenticatorSpec extends RequestAuthenticatorSpec {
     val dummyStore = dummyBackingStore[IO, Int, DummyUser](_.id)
     val macKey     = macKeyGen.generateKeyUnsafe()
     val cryptoKey  = eKeyGen.generateKeyUnsafe()
-    val auth = JWTAuthenticator.withBackingStore[IO, A, Int, DummyUser, E](
+    val auth = JWTAuthenticator.withBackingStore[IO, Int, DummyUser, A, E](
       settings,
       store,
       dummyStore,
@@ -75,7 +75,7 @@ class JWTAuthenticatorSpec extends RequestAuthenticatorSpec {
 
       def wrongKeyAuthenticator: OptionT[IO, JWTMac[A]] =
         JWTAuthenticator
-          .withBackingStore[IO, A, Int, DummyUser, E](
+          .withBackingStore[IO, Int, DummyUser, A, E](
             settings,
             store,
             dummyStore,
@@ -95,7 +95,7 @@ class JWTAuthenticatorSpec extends RequestAuthenticatorSpec {
     val dummyStore = dummyBackingStore[IO, Int, DummyUser](_.id)
     val macKey     = macKeyGen.generateKeyUnsafe()
     val cryptoKey  = eKeyGen.generateKeyUnsafe()
-    val auth = JWTAuthenticator.stateless[IO, A, Int, DummyUser, E](
+    val auth = JWTAuthenticator.stateless[IO, Int, DummyUser, A, E](
       settings,
       dummyStore,
       macKey,
@@ -128,7 +128,7 @@ class JWTAuthenticatorSpec extends RequestAuthenticatorSpec {
 
       def wrongKeyAuthenticator: OptionT[IO, JWTMac[A]] =
         JWTAuthenticator
-          .stateless[IO, A, Int, DummyUser, E](
+          .stateless[IO, Int, DummyUser, A, E](
             settings,
             dummyStore,
             macKeyGen.generateKeyUnsafe(),

--- a/tsec-http4s/src/test/scala/tsec/authentication/RequestAuthenticatorSpec.scala
+++ b/tsec-http4s/src/test/scala/tsec/authentication/RequestAuthenticatorSpec.scala
@@ -18,13 +18,13 @@ class RequestAuthenticatorSpec extends AuthenticatorSpec {
 
     val dummyBob = DummyUser(0)
 
-    val requestAuth: SecuredRequestHandler[IO, Int, DummyUser, A] = SecuredRequestHandler(authSpec.auth)
+    val requestAuth = SecuredRequestHandler(authSpec.auth)
 
     //Add bob to the db
     authSpec.dummyStore.put(dummyBob).unsafeRunSync()
 
-    val onlyAdmins = BasicRBAC[IO, DummyRole, DummyUser](DummyRole.Admin)
-    val everyone   = BasicRBAC.all[IO, DummyRole, DummyUser]
+    val onlyAdmins = BasicRBAC[IO, DummyRole, DummyUser, A](DummyRole.Admin)
+    val everyone   = BasicRBAC.all[IO, DummyRole, DummyUser, A]
 
     val testService: HttpService[IO] = requestAuth {
       case request @ GET -> Root / "api" asAuthed hi =>

--- a/tsec-http4s/src/test/scala/tsec/authentication/SignedCookieAuthenticatorTests.scala
+++ b/tsec-http4s/src/test/scala/tsec/authentication/SignedCookieAuthenticatorTests.scala
@@ -22,7 +22,7 @@ class SignedCookieAuthenticatorTests extends RequestAuthenticatorSpec {
       store: BackingStore[IO, UUID, AuthenticatedCookie[A, Int]]
   ): AuthSpecTester[AuthenticatedCookie[A, Int]] = {
     val dummyStore = dummyBackingStore[IO, Int, DummyUser](_.id)
-    val authenticator = CookieAuthenticator[IO, A, Int, DummyUser](
+    val authenticator = CookieAuthenticator[IO, Int, DummyUser, A](
       TSecCookieSettings(cookieName, false, expiryDuration = 10.minutes, maxIdle = Some(10.minutes)),
       store,
       dummyStore,
@@ -32,7 +32,6 @@ class SignedCookieAuthenticatorTests extends RequestAuthenticatorSpec {
 
       def embedInRequest(request: Request[IO], authenticator: AuthenticatedCookie[A, Int]): Request[IO] =
         request.addCookie(authenticator.toCookie)
-
 
       def expireAuthenticator(b: AuthenticatedCookie[A, Int]): OptionT[IO, AuthenticatedCookie[A, Int]] = {
         val now     = Instant.now()
@@ -47,7 +46,7 @@ class SignedCookieAuthenticatorTests extends RequestAuthenticatorSpec {
       }
 
       def wrongKeyAuthenticator: OptionT[IO, AuthenticatedCookie[A, Int]] =
-        CookieAuthenticator[IO, A, Int, DummyUser](
+        CookieAuthenticator[IO, Int, DummyUser, A](
           TSecCookieSettings(cookieName, false, expiryDuration = 10.minutes, maxIdle = Some(10.minutes)),
           store,
           dummyStore,


### PR DESCRIPTION
I'm changing `Authorization[F, UserType]` to `Authorization[F, UserType, Authenticator]`. 

The primary reason is the fact that some Authorization logic may involve expensive operations, such as [the conversation here](https://gitter.im/http4s/http4s/archives/2017/11/06), which you would want to cache tokens for. In this case, this opens the `Authorization` trait to be open for extensibility for such operations without a complicated typeclass that may have to support _all_ token types.