### PR TITLE
Fix tsec middleware and CSRF

### DIFF
--- a/docs/src/main/tut/docs/http4s-auth.md
+++ b/docs/src/main/tut/docs/http4s-auth.md
@@ -154,6 +154,9 @@ Then turn this into an `HttpService[F]`  by applying the middleware you used bef
   val service: HttpService[IO] = middleware(authservice)
 ```
 
+In essence, this is captured by `SecuredRequestHandler`, which wraps the process of having to create the service
+and the middleware for you in a simple `apply` method, so you only have to worry about creating the route. See the examples
+on specific authenticators for more.
 
 ## Stateful vs Stateless
 

--- a/tsec-http4s/src/main/scala/tsec/authentication/SecuredRequestHandler.scala
+++ b/tsec-http4s/src/main/scala/tsec/authentication/SecuredRequestHandler.scala
@@ -35,25 +35,25 @@ object SecuredRequestHandler {
       new SecuredRequestHandler[F, Identity, User, Auth](authenticator) {
         def apply(pf: PartialFunction[SecuredRequest[F, User, Auth], F[Response[F]]]): HttpService[F] =
           middleware(TSecAuthService(pf))
-            .handleError(_ => Response[F](Status.Forbidden))
+            .handleError(_ => Response[F](Status.Unauthorized))
 
         def authorized(authorization: Authorization[F, User, Auth])(
             pf: PartialFunction[SecuredRequest[F, User, Auth], F[Response[F]]]
         ): HttpService[F] =
           authorizedMiddleware(authorization)(TSecAuthService(pf))
-            .handleError(_ => Response[F](Status.Forbidden))
+            .handleError(_ => Response[F](Status.Unauthorized))
       }
     } else
       new SecuredRequestHandler[F, Identity, User, Auth](authenticator) {
         def apply(pf: PartialFunction[SecuredRequest[F, User, Auth], F[Response[F]]]): HttpService[F] =
           middleware(TSecAuthService(pf, authenticator.afterBlock))
-            .handleError(_ => Response[F](Status.Forbidden))
+            .handleError(_ => Response[F](Status.Unauthorized))
 
         def authorized(
             authorization: Authorization[F, User, Auth]
         )(pf: PartialFunction[SecuredRequest[F, User, Auth], F[Response[F]]]): HttpService[F] =
           authorizedMiddleware(authorization)(TSecAuthService(pf, authenticator.afterBlock))
-            .handleError(_ => Response[F](Status.Forbidden))
+            .handleError(_ => Response[F](Status.Unauthorized))
       }
   }
 }

--- a/tsec-http4s/src/main/scala/tsec/authentication/package.scala
+++ b/tsec-http4s/src/main/scala/tsec/authentication/package.scala
@@ -56,7 +56,9 @@ package object authentication {
         authedStuff: Kleisli[OptionT[F, ?], Request[F], SecuredRequest[F, Ident, Auth]]
     ): TSecMiddleware[F, Ident, Auth] =
       service => {
-        service.compose(authedStuff)
+        authedStuff
+          .andThen(service.mapF(o => OptionT.liftF(o.fold(Response[F](Status.NotFound))(identity))))
+          .mapF(o => OptionT.liftF(o.fold(Response[F](Status.Unauthorized))(identity)))
       }
   }
 

--- a/tsec-http4s/src/test/scala/tsec/authentication/BearerTokenAuthenticatorTests.scala
+++ b/tsec-http4s/src/test/scala/tsec/authentication/BearerTokenAuthenticatorTests.scala
@@ -30,7 +30,7 @@ class BearerTokenAuthenticatorTests extends RequestAuthenticatorSpec {
         authenticator.update(b.copy(lastTouched = Some(Instant.now.minusSeconds(300000))))
 
       def wrongKeyAuthenticator: OptionT[IO, TSecBearerToken[Int]] =
-        OptionT.none
+        OptionT.pure(TSecBearerToken(SecureRandomId.generate, -20, Instant.now(), None))
     }
   }
 

--- a/tsec-http4s/src/test/scala/tsec/authentication/RequestAuthenticatorSpec.scala
+++ b/tsec-http4s/src/test/scala/tsec/authentication/RequestAuthenticatorSpec.scala
@@ -6,6 +6,8 @@ import io.circe.Json
 import org.http4s.dsl.io._
 import org.http4s.circe._
 import org.http4s._
+import cats.syntax.all._
+import org.http4s.implicits._
 import io.circe.syntax._
 import io.circe.generic.auto._
 import tsec.authorization.BasicRBAC
@@ -49,7 +51,7 @@ class RequestAuthenticatorSpec extends AuthenticatorSpec {
         res <- testService(embedded)
       } yield res
       response
-        .getOrElse(Response[IO](status = Status.Forbidden))
+        .getOrElse(Response.notFound)
         .flatMap(_.attemptAs[Json].value.map(_.flatMap(_.as[DummyUser])))
         .unsafeRunSync() mustBe Right(dummyBob)
     }
@@ -62,9 +64,9 @@ class RequestAuthenticatorSpec extends AuthenticatorSpec {
         res <- testService(embedded)
       } yield res
       response
-        .getOrElse(Response[IO](status = Status.Forbidden))
+        .getOrElse(Response.notFound)
         .map(_.status)
-        .unsafeRunSync() mustBe Status.Forbidden
+        .unsafeRunSync() mustBe Status.Unauthorized
     }
 
     it should "work on a renewed token" in {
@@ -77,7 +79,7 @@ class RequestAuthenticatorSpec extends AuthenticatorSpec {
         res <- testService(embedded)
       } yield res
       response
-        .getOrElse(Response[IO](status = Status.Forbidden))
+        .getOrElse(Response.notFound)
         .flatMap(_.attemptAs[Json].value.map(_.flatMap(_.as[DummyUser])))
         .unsafeRunSync() mustBe Right(dummyBob)
     }
@@ -90,9 +92,9 @@ class RequestAuthenticatorSpec extends AuthenticatorSpec {
         res <- testService(embedded)
       } yield res
       response
-        .getOrElse(Response[IO](status = Status.Forbidden))
+        .getOrElse(Response.notFound)
         .map(_.status)
-        .unsafeRunSync() mustBe Status.Forbidden
+        .unsafeRunSync() mustBe Status.Unauthorized
     }
 
     it should "work on a refreshed token" in {
@@ -105,7 +107,7 @@ class RequestAuthenticatorSpec extends AuthenticatorSpec {
         res <- testService(embedded)
       } yield res
       response
-        .getOrElse(Response[IO](status = Status.Forbidden))
+        .getOrElse(Response.notFound)
         .flatMap(_.attemptAs[Json].value.map(_.flatMap(_.as[DummyUser])))
         .unsafeRunSync() mustBe Right(dummyBob)
     }
@@ -118,9 +120,9 @@ class RequestAuthenticatorSpec extends AuthenticatorSpec {
         res <- testService(embedded)
       } yield res
       response
-        .getOrElse(Response[IO](status = Status.Forbidden))
+        .getOrElse(Response.notFound)
         .map(_.status)
-        .unsafeRunSync() mustBe Status.Forbidden
+        .unsafeRunSync() mustBe Status.Unauthorized
     }
 
     //note: we feed it "discarded" because stateless tokens rely on this.
@@ -132,9 +134,9 @@ class RequestAuthenticatorSpec extends AuthenticatorSpec {
         res <- testService(embedded)
       } yield res
       response
-        .getOrElse(Response[IO](status = Status.Forbidden))
+        .getOrElse(Response.notFound)
         .map(_.status)
-        .unsafeRunSync() mustBe Status.Forbidden
+        .unsafeRunSync() mustBe Status.Unauthorized
     }
 
     it should "authorize for an allowed endpoint" in {
@@ -156,9 +158,9 @@ class RequestAuthenticatorSpec extends AuthenticatorSpec {
         res <- adminService(embedded)
       } yield res
       response
-        .getOrElse(Response[IO](status = Status.Forbidden))
+        .getOrElse(Response.notFound)
         .map(_.status)
-        .unsafeRunSync() mustBe Status.Forbidden
+        .unsafeRunSync() mustBe Status.Unauthorized
     }
   }
 


### PR DESCRIPTION
* TSecMiddleware will now entirely consume requests, similar to pr #1530 on http4s.
* CSRFMiddleware will now produce a _new_ token on a request from the last one, to mitigate BREACH