### PR TITLE
Hex encoders and csrf hotfixes

### DIFF
--- a/common/src/main/scala/tsec/common/SecureRandomIdGenerator.scala
+++ b/common/src/main/scala/tsec/common/SecureRandomIdGenerator.scala
@@ -7,7 +7,7 @@ case class SecureRandomIdGenerator(sizeInBytes: Int = 32) extends ManagedRandom 
   def generate: SecureRandomId = {
     val byteArray = new Array[Byte](sizeInBytes)
     nextBytes(byteArray)
-    SecureRandomId$$.is.flip.coerce(Hex.encodeHexString(byteArray))
+    SecureRandomId$$.is.flip.coerce(new String(Hex.encodeHex(byteArray)))
   }
 }
 

--- a/common/src/main/scala/tsec/common/package.scala
+++ b/common/src/main/scala/tsec/common/package.scala
@@ -3,6 +3,8 @@ package tsec
 import java.nio.charset.StandardCharsets
 import java.util.Base64
 
+import cats.effect.Sync
+import org.apache.commons.codec.binary.Hex
 import cats.evidence.Is
 
 package object common {
@@ -44,11 +46,13 @@ package object common {
   }
 
   final class JerryStringer(val s: String) extends AnyVal {
-    def utf8Bytes: Array[Byte]                             = s.getBytes(StandardCharsets.UTF_8)
-    def asciiBytes: Array[Byte]                            = s.getBytes(StandardCharsets.US_ASCII)
-    def base64Bytes: Array[Byte]                           = Base64.getDecoder.decode(s)
-    def base64UrlBytes: Array[Byte]                        = Base64.getUrlDecoder.decode(s)
-    def toStringRepr[A](implicit stringEV: StringEV[A]): A = stringEV.fromString(s)
+    def utf8Bytes: Array[Byte]                              = s.getBytes(StandardCharsets.UTF_8)
+    def asciiBytes: Array[Byte]                             = s.getBytes(StandardCharsets.US_ASCII)
+    def base64Bytes: Array[Byte]                            = Base64.getDecoder.decode(s)
+    def base64UrlBytes: Array[Byte]                         = Base64.getUrlDecoder.decode(s)
+    def hexBytes[F[_]](implicit F: Sync[F]): F[Array[Byte]] = F.delay(Hex.decodeHex(s))
+    def hexBytesUnsafe: Array[Byte]                         = Hex.decodeHex(s)
+    def toStringRepr[A](implicit stringEV: StringEV[A]): A  = stringEV.fromString(s)
   }
 
   final class ByteSyntaxHelpers(val array: Array[Byte]) extends AnyVal {
@@ -56,6 +60,7 @@ package object common {
     def toAsciiString                            = new String(array, StandardCharsets.US_ASCII)
     def toB64UrlString: String                   = Base64.getUrlEncoder.encodeToString(array)
     def toB64String: String                      = Base64.getEncoder.encodeToString(array)
+    def toHexString: String                      = Hex.encodeHexString(array)
     def toRepr[A](implicit byteEV: ByteEV[A]): A = byteEV.fromArray(array)
   }
 

--- a/tsec-http4s/src/main/scala/tsec/csrf/TSecCSRF.scala
+++ b/tsec-http4s/src/main/scala/tsec/csrf/TSecCSRF.scala
@@ -77,12 +77,12 @@ final case class TSecCSRF[F[_]: Sync, A: MacTag: ByteEV](
           raw2     <- extractRaw(CSRFToken(c2))
           res      <- if (isEqual(raw1, raw2)) req(r) else OptionT.none
           newToken <- OptionT.liftF(signToken(raw1)) //Generate a new token to guard against BREACH.
-        } yield res.addCookie(Cookie(name = cookieName, content = newToken, httpOnly = true))
+        } yield res.addCookie(Cookie(name = cookieName, content = newToken))
     }.mapF(f => OptionT.liftF(f.getOrElse(Response[F](Status.Forbidden))))
 
-  def withNewToken: CSRFMiddleware[F] = _.andThen(r => OptionT.liftF(embed(r)))
+  def withNewToken: CSRFMiddleware[F] = _.andThen(r => OptionT.liftF(embedNew(r)))
 
-  def embed(response: Response[F]): F[Response[F]] =
-    generateNewToken.map(t => response.addCookie(Cookie(name = cookieName, content = t, httpOnly = true)))
+  def embedNew(response: Response[F]): F[Response[F]] =
+    generateNewToken.map(t => response.addCookie(Cookie(name = cookieName, content = t)))
 
 }

--- a/tsec-http4s/src/main/scala/tsec/csrf/TSecCSRF.scala
+++ b/tsec-http4s/src/main/scala/tsec/csrf/TSecCSRF.scala
@@ -38,7 +38,7 @@ final case class TSecCSRF[F[_]: Sync, A: MacTag: ByteEV](
 
   def signToken(string: String): F[CSRFToken] = {
     val joined = string + "-" + clock.millis()
-    mac.sign(joined.utf8Bytes, key).map(s => CSRFToken(joined + "-" + s.asByteArray.toB64UrlString))
+    mac.sign(joined.utf8Bytes, key).map(s => CSRFToken(joined + "-" + s.asByteArray.toB64String))
   }
 
   def generateNewToken: F[CSRFToken] =
@@ -54,7 +54,7 @@ final case class TSecCSRF[F[_]: Sync, A: MacTag: ByteEV](
           mac
             .sign((raw + "-" + nonce).utf8Bytes, key)
             .map(
-              f => if (MessageDigest.isEqual(f.asByteArray, signed.base64UrlBytes)) Some(raw) else None
+              f => if (MessageDigest.isEqual(f.asByteArray, signed.base64Bytes)) Some(raw) else None
             )
         )
       case _ =>


### PR DESCRIPTION
* CSRF has a bug I didn't notice before due to trying to make a clean implementation: It will set `Set-Cookie` to a `Forbidden` response that failed validation. This is _BAD_, as this can leak the token. This hotfixes it, and will make it into a quick M5
* The CSRF response had the `httpOnly` flag set to `true`, which means it wouldn't be accessed by the client side. We _want_ it to be accessed by clients, but only on the right domain, thus it shouldn't have this flag set.
* `SecureRandomId` will now return only uppercase Hex characters. This doesn't mean anything security-wise, just it was the behavior I intended from the beginning
* A few helpers for returning and decoding hex strings.