### PR TITLE
JWTMAC fixes 

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -46,7 +46,7 @@ lazy val commonSettings = Seq(
   fork in test := true,
   parallelExecution in test := false,
   addCompilerPlugin("org.spire-math" %% "kind-projector" % "0.9.4"),
-  version in ThisBuild := "0.0.1-M4",
+  version in ThisBuild := "0.0.1-M5",
   scalacOpts
 )
 

--- a/examples/src/main/scala/JWTMacExamples.scala
+++ b/examples/src/main/scala/JWTMacExamples.scala
@@ -1,3 +1,6 @@
+
+
+
 object JWTMacExamples {
 
   import tsec.jwt._
@@ -18,17 +21,18 @@ object JWTMacExamples {
     parsed          <- JWTMac.verifyAndParse[HMACSHA256](stringjwt, key) //Or verify and return the actual instance
   } yield parsed
 
-  import cats.effect.IO
+  import cats.syntax.all._
+  import cats.effect.Sync
 
   /** You can also chose to interpret into any target Monad with an instance of MonadError[F, Throwable] using JwtMacM */
-  val jwtMonadic: IO[JWTMac[HMACSHA256]] = for {
-    key <- HMACSHA256.generateLift[IO]
-    jwt <- JWTMacM.build[IO, HMACSHA256](claims, key) //You can sign and build a jwt object directly
+  def jwtMonadic[F[_]: Sync]: F[JWTMac[HMACSHA256]] = for {
+    key <- HMACSHA256.generateLift[F]
+    jwt <- JWTMacM.build[F, HMACSHA256](claims, key) //You can sign and build a jwt object directly
     verifiedFromObj <- JWTMacM
-      .verifyFromInstance[IO, HMACSHA256](jwt, key) //You can verify the jwt straight from an object
-    stringjwt  <- JWTMacM.buildToString[IO, HMACSHA256](claims, key)       //Or build it straight to string
-    isverified <- JWTMacM.verifyFromString[IO, HMACSHA256](stringjwt, key) //You can verify straight from a string
-    parsed     <- JWTMacM.verifyAndParse[IO, HMACSHA256](stringjwt, key)   //Or verify and return the actual instance
+      .verifyFromInstance[F, HMACSHA256](jwt, key) //You can verify the jwt straight from an object
+    stringjwt  <- JWTMacM.buildToString[F, HMACSHA256](claims, key)       //Or build it straight to string
+    isverified <- JWTMacM.verifyFromString[F, HMACSHA256](stringjwt, key) //You can verify straight from a string
+    parsed     <- JWTMacM.verifyAndParse[F, HMACSHA256](stringjwt, key)   //Or verify and return the actual instance
   } yield parsed
 
 }

--- a/jwt-mac/src/main/scala/tsec/jws/mac/JWSMacCV.scala
+++ b/jwt-mac/src/main/scala/tsec/jws/mac/JWSMacCV.scala
@@ -98,12 +98,7 @@ object JWSMacCV {
       alg: JCAMacPure[F, A],
   ): JWSMacCV[F, A] =
     new JWSMacCV[F, A]() {}
-//
-//  implicit def genSignerIO[A: ByteEV](
-//      implicit hs: JWSSerializer[JWSMacHeader[A]],
-//      alg: JCAMacPure[IO, A]
-//  ): JWSMacCV[IO, A] =
-//    new JWSMacCV[IO, A]() {}
+
 
   implicit def genSignerEither[A: MacTag: ByteEV](
       implicit hs: JWSSerializer[JWSMacHeader[A]],

--- a/jwt-mac/src/main/scala/tsec/jws/mac/JWSMacCV.scala
+++ b/jwt-mac/src/main/scala/tsec/jws/mac/JWSMacCV.scala
@@ -1,7 +1,7 @@
 package tsec.jws.mac
 
 import cats.{Monad, MonadError}
-import cats.effect.{Effect, IO}
+import cats.effect.{Effect, IO, Sync}
 import cats.implicits._
 import tsec.common._
 import tsec.jws._
@@ -45,8 +45,7 @@ sealed abstract class JWSMacCV[F[_], A](
     programs.sign(toSign.asciiBytes, key).map(s => toSign + "." + aux.toArray(s).toB64UrlString)
   }
 
-  def verify(jwt: String, key: MacSigningKey[A]): F[Boolean] = {
-    val now: Instant         = Instant.now()
+  def verify(jwt: String, key: MacSigningKey[A], now: Instant): F[Boolean] = {
     val split: Array[String] = jwt.split("\\.", 3)
     if (split.length < 3)
       M.pure(false)
@@ -68,8 +67,7 @@ sealed abstract class JWSMacCV[F[_], A](
     }
   }
 
-  def verifyAndParse(jwt: String, key: MacSigningKey[A]): F[JWTMac[A]] = {
-    val now   = Instant.now
+  def verifyAndParse(jwt: String, key: MacSigningKey[A], now: Instant): F[JWTMac[A]] = {
     val split = jwt.split("\\.", 3)
     if (split.length != 3)
       M.raiseError(defaultError)
@@ -95,20 +93,19 @@ sealed abstract class JWSMacCV[F[_], A](
 
 object JWSMacCV {
 
-  implicit def genSigner[F[_], A: ByteEV](
+  implicit def genSigner[F[_]: Sync, A: ByteEV: MacTag](
       implicit hs: JWSSerializer[JWSMacHeader[A]],
-      alg: MacPrograms[F, A, MacSigningKey],
-      monadError: MonadError[F, Throwable]
+      alg: JCAMacPure[F, A],
   ): JWSMacCV[F, A] =
     new JWSMacCV[F, A]() {}
+//
+//  implicit def genSignerIO[A: ByteEV](
+//      implicit hs: JWSSerializer[JWSMacHeader[A]],
+//      alg: JCAMacPure[IO, A]
+//  ): JWSMacCV[IO, A] =
+//    new JWSMacCV[IO, A]() {}
 
-  implicit def genSignerIO[A: ByteEV](
-      implicit hs: JWSSerializer[JWSMacHeader[A]],
-      alg: JCAMacPure[IO, A]
-  ): JWSMacCV[IO, A] =
-    new JWSMacCV[IO, A]() {}
-
-  implicit def genSignerEither[A: ByteEV](
+  implicit def genSignerEither[A: MacTag: ByteEV](
       implicit hs: JWSSerializer[JWSMacHeader[A]],
       alg: JCAMacImpure[A]
   ): JWSMacCV[MacErrorM, A] =


### PR DESCRIPTION
* JWTMacM now requires `Sync[F]`, JWTMac stays the same. This makes sense, the monadic one needs a way to suspend the side effect of checking the clock.
* Time is now properly handled, since it is taken as a parameter to `JWTMacCV` functions which is handled in a non-side effecting way for the pure methods