### PR TITLE
fix private Is in types #55

### DIFF
--- a/mac/src/main/scala/tsec/mac/imports/package.scala
+++ b/mac/src/main/scala/tsec/mac/imports/package.scala
@@ -4,6 +4,8 @@ import cats.evidence.Is
 import tsec.common._
 import javax.crypto.{SecretKey => JSecretKey}
 
+import tsec.mac.imports.MacSigningKey$$
+
 package object imports {
 
   type MacErrorM[A] = Either[Throwable, A]
@@ -17,23 +19,27 @@ package object imports {
 
   implicit object HMACSHA1 extends WithMacSigningKey[HMACSHA1]("HmacSHA1", 20) with ByteEV[HMACSHA1] {
 
+    @inline def is: Is[HMACSHA1, Array[Byte]] = HMACSHA1$$.is
+
     @inline def fromArray(array: Array[Byte]): HMACSHA1 = HMACSHA1$$.is.flip.coerce(array)
 
     @inline def toArray(a: HMACSHA1): Array[Byte] = HMACSHA1$$.is.coerce(a)
   }
 
-  protected val HMACSHA256tagged: TaggedByteArray = new TaggedByteArray {
+  protected val HMACSHA256$$ : TaggedByteArray = new TaggedByteArray {
     type I = Array[Byte]
     val is = Is.refl[Array[Byte]]
   }
 
-  type HMACSHA256 = HMACSHA256tagged.I
+  type HMACSHA256 = HMACSHA256$$.I
 
   implicit object HMACSHA256 extends WithMacSigningKey[HMACSHA256]("HmacSHA256", 32) with ByteEV[HMACSHA256] {
 
-    @inline def fromArray(array: Array[Byte]): HMACSHA256 = HMACSHA256tagged.is.flip.coerce(array)
+    @inline def is: Is[HMACSHA256, Array[Byte]] = HMACSHA256$$.is
 
-    @inline def toArray(a: HMACSHA256): Array[Byte] = HMACSHA256tagged.is.coerce(a)
+    @inline def fromArray(array: Array[Byte]): HMACSHA256 = HMACSHA256$$.is.flip.coerce(array)
+
+    @inline def toArray(a: HMACSHA256): Array[Byte] = HMACSHA256$$.is.coerce(a)
   }
 
   protected val HMACSHA384$$ : TaggedByteArray = new TaggedByteArray {
@@ -44,6 +50,8 @@ package object imports {
   type HMACSHA384 = HMACSHA384$$.I
 
   implicit object HMACSHA384 extends WithMacSigningKey[HMACSHA384]("HmacSHA384", 48) with ByteEV[HMACSHA384] {
+
+    @inline def is: Is[HMACSHA384, Array[Byte]] = HMACSHA384$$.is
 
     @inline def fromArray(array: Array[Byte]): HMACSHA384 = HMACSHA384$$.is.flip.coerce(array)
 
@@ -58,6 +66,8 @@ package object imports {
   type HMACSHA512 = HMACSHA512$$.I
 
   implicit object HMACSHA512 extends WithMacSigningKey[HMACSHA512]("HmacSHA512", 64) with ByteEV[HMACSHA512] {
+
+    @inline def is: Is[HMACSHA512, Array[Byte]] = HMACSHA512$$.is
 
     @inline def fromArray(array: Array[Byte]): HMACSHA512 = HMACSHA512$$.is.flip.coerce(array)
 
@@ -79,6 +89,7 @@ package object imports {
   type MacSigningKey[A] = MacSigningKey$$.Repr[A]
 
   object MacSigningKey {
+    def is[A]: Is[MacSigningKey[A], JSecretKey]                           = MacSigningKey$$.is[A]
     @inline def fromJavaKey[A: MacTag](key: JSecretKey): MacSigningKey[A] = MacSigningKey$$.is[A].flip.coerce(key)
     @inline def toJavaKey[A: MacTag](key: MacSigningKey[A]): JSecretKey   = MacSigningKey$$.is[A].coerce(key)
   }

--- a/message-digests/src/main/scala/tsec/messagedigests/imports/package.scala
+++ b/message-digests/src/main/scala/tsec/messagedigests/imports/package.scala
@@ -17,6 +17,8 @@ package object imports {
 
   implicit object MD5 extends DeriveHashTag[MD5]("MD5") with ByteEV[MD5] {
 
+    @inline def is: Is[MD5, Array[Byte]] = MD5$$.is
+
     @inline def fromArray(array: Array[Byte]): MD5 = MD5$$.is.flip.coerce(array)
 
     @inline def toArray(a: MD5): Array[Byte] = MD5$$.is.coerce(a)
@@ -30,6 +32,8 @@ package object imports {
   type SHA1 = SHA1$$.I
 
   implicit object SHA1 extends DeriveHashTag[SHA1]("SHA-1") with ByteEV[SHA1] {
+
+    @inline def is: Is[SHA1, Array[Byte]] = SHA1$$.is
 
     @inline def fromArray(array: Array[Byte]): SHA1 = SHA1$$.is.flip.coerce(array)
 
@@ -45,6 +49,8 @@ package object imports {
 
   implicit object SHA256 extends DeriveHashTag[SHA256]("SHA-256") with ByteEV[SHA256] {
 
+    @inline def is: Is[SHA256, Array[Byte]] = SHA256$$.is
+
     @inline def fromArray(array: Array[Byte]): SHA256 = SHA256$$.is.flip.coerce(array)
 
     @inline def toArray(a: SHA256): Array[Byte] = SHA256$$.is.coerce(a)
@@ -58,6 +64,8 @@ package object imports {
   type SHA512 = SHA512$$.I
 
   implicit object SHA512 extends DeriveHashTag[SHA512]("SHA-512") with ByteEV[SHA512] {
+
+    @inline def is: Is[SHA512, Array[Byte]] = SHA512$$.is
 
     @inline def fromArray(array: Array[Byte]): SHA512 = SHA512$$.is.flip.coerce(array)
 

--- a/password-hashers/src/main/scala/tsec/passwordhashers/imports/package.scala
+++ b/password-hashers/src/main/scala/tsec/passwordhashers/imports/package.scala
@@ -5,6 +5,7 @@ import tsec.passwordhashers.core._
 import org.mindrot.jbcrypt.{BCrypt => JBCrypt}
 import com.lambdaworks.crypto.{SCryptUtil => JSCrypt}
 import tsec.common.{StringEV, TaggedString}
+import tsec.passwordhashers.imports.{BCrypt$$, HardenedSCrypt$$, SCrypt$$}
 
 package object imports {
 
@@ -31,6 +32,8 @@ package object imports {
   type BCrypt = BCrypt$$.I
 
   implicit object BCrypt extends PasswordHasher[BCrypt] with StringEV[BCrypt] {
+    @inline def is: Is[BCrypt, String] = BCrypt$$.is
+
     @inline def fromString(a: String): BCrypt = BCrypt$$.is.flip.coerce(a)
 
     @inline def asString(a: BCrypt): String = BCrypt$$.is.coerce(a)
@@ -57,6 +60,8 @@ package object imports {
   type SCrypt = SCrypt$$.I
 
   implicit object SCrypt extends PasswordHasher[SCrypt] with StringEV[SCrypt] {
+    @inline def is: Is[SCrypt, String] = SCrypt$$.is
+
     @inline def fromString(a: String): SCrypt = SCrypt$$.is.flip.coerce(a)
 
     @inline def asString(a: SCrypt): String = SCrypt$$.is.coerce(a)
@@ -76,7 +81,7 @@ package object imports {
   implicit object SCryptPasswordHasher
       extends PWHashPrograms[PasswordValidated, SCrypt](SCryptAlgebra, Rounds(DefaultSCryptN))(SCrypt)
 
-  val HardenedSCrypt$$ : TaggedString = new TaggedString {
+  protected val HardenedSCrypt$$ : TaggedString = new TaggedString {
     type I = String
     val is = Is.refl[String]
   }
@@ -84,6 +89,7 @@ package object imports {
   type HardenedSCrypt = HardenedSCrypt$$.I
 
   implicit object HardenedSCrypt extends PasswordHasher[HardenedSCrypt] with StringEV[HardenedSCrypt] {
+    @inline def is: Is[HardenedSCrypt, String] = HardenedSCrypt$$.is
 
     @inline def fromString(a: String): HardenedSCrypt = HardenedSCrypt$$.is.flip.coerce(a)
 

--- a/signatures/src/main/scala/tsec/signature/imports/package.scala
+++ b/signatures/src/main/scala/tsec/signature/imports/package.scala
@@ -17,6 +17,7 @@ package object imports {
   type MD2withRSA = MD2withRSA$$.I
 
   implicit object MD2withRSA extends GeneralSignature[MD2withRSA]("MD2withRSA", "RSA") with ByteEV[MD2withRSA] {
+    @inline def is: Is[MD2withRSA, Array[Byte]] = MD2withRSA$$.is
 
     @inline def fromArray(array: Array[Byte]): MD2withRSA = MD2withRSA$$.is.flip.coerce(array)
 
@@ -31,6 +32,7 @@ package object imports {
   type MD5withRSA = MD5withRSA$$.I
 
   implicit object MD5withRSA extends GeneralSignature[MD5withRSA]("MD5withRSA", "RSA") with ByteEV[MD5withRSA] {
+    @inline def is: Is[MD5withRSA, Array[Byte]] = MD5withRSA$$.is
 
     @inline def fromArray(array: Array[Byte]): MD5withRSA = MD5withRSA$$.is.flip.coerce(array)
 
@@ -45,6 +47,7 @@ package object imports {
   type SHA1withRSA = SHA1withRSA$$.I
 
   implicit object SHA1withRSA extends GeneralSignature[SHA1withRSA]("SHA1withRSA", "RSA") with ByteEV[SHA1withRSA] {
+    @inline def is: Is[SHA1withRSA, Array[Byte]] = SHA1withRSA$$.is
 
     @inline def fromArray(array: Array[Byte]): SHA1withRSA = SHA1withRSA$$.is.flip.coerce(array)
 
@@ -75,6 +78,7 @@ package object imports {
   type SHA256withRSA = SHA256withRSA$$.I
 
   implicit object SHA256withRSA extends RSASignature[SHA256withRSA]("SHA256withRSA") with ByteEV[SHA256withRSA] {
+    @inline def is: Is[SHA256withRSA, Array[Byte]] = SHA256withRSA$$.is
 
     @inline def fromArray(array: Array[Byte]): SHA256withRSA = SHA256withRSA$$.is.flip.coerce(array)
 
@@ -89,6 +93,7 @@ package object imports {
   type SHA384withRSA = SHA384withRSA$$.I
 
   implicit object SHA384withRSA extends RSASignature[SHA384withRSA]("SHA384withRSA") with ByteEV[SHA384withRSA] {
+    @inline def is: Is[SHA384withRSA, Array[Byte]] = SHA384withRSA$$.is
 
     @inline def fromArray(array: Array[Byte]): SHA384withRSA = SHA384withRSA$$.is.flip.coerce(array)
 
@@ -103,6 +108,7 @@ package object imports {
   type SHA512withRSA = SHA512withRSA$$.I
 
   implicit object SHA512withRSA extends RSASignature[SHA512withRSA]("SHA512withRSA") with ByteEV[SHA512withRSA] {
+    @inline def is: Is[SHA512withRSA, Array[Byte]] = SHA512withRSA$$.is
 
     @inline def fromArray(array: Array[Byte]): SHA512withRSA = SHA512withRSA$$.is.flip.coerce(array)
 
@@ -117,6 +123,7 @@ package object imports {
   type SHA1withDSA = SHA1withDSA$$.I
 
   implicit object SHA1withDSA extends GeneralSignature[SHA1withDSA]("SHA1withDSA", "DSA") with ByteEV[SHA1withDSA] {
+    @inline def is: Is[SHA1withDSA, Array[Byte]] = SHA1withDSA$$.is
 
     @inline def fromArray(array: Array[Byte]): SHA1withDSA = SHA1withDSA$$.is.flip.coerce(array)
 
@@ -133,6 +140,7 @@ package object imports {
   implicit object SHA224withDSA
       extends GeneralSignature[SHA224withDSA]("SHA224withDSA", "DSA")
       with ByteEV[SHA224withDSA] {
+    @inline def is: Is[SHA224withDSA, Array[Byte]] = SHA224withDSA$$.is
 
     @inline def fromArray(array: Array[Byte]): SHA224withDSA = SHA224withDSA$$.is.flip.coerce(array)
 
@@ -149,6 +157,7 @@ package object imports {
   implicit object SHA256withDSA
       extends GeneralSignature[SHA256withDSA]("SHA256withDSA", "DSA")
       with ByteEV[SHA256withDSA] {
+    @inline def is: Is[SHA256withDSA, Array[Byte]] = SHA256withDSA$$.is
 
     @inline def fromArray(array: Array[Byte]): SHA256withDSA = SHA256withDSA$$.is.flip.coerce(array)
 
@@ -165,6 +174,7 @@ package object imports {
   implicit object NONEwithECDSA
       extends GeneralSignature[NONEwithECDSA]("NONEwithECDSA", "ECDSA")
       with ByteEV[NONEwithECDSA] {
+    @inline def is: Is[NONEwithECDSA, Array[Byte]] = NONEwithECDSA$$.is
 
     @inline def fromArray(array: Array[Byte]): NONEwithECDSA = NONEwithECDSA$$.is.flip.coerce(array)
 
@@ -184,6 +194,7 @@ package object imports {
   implicit object SHA1withECDSA
       extends GeneralSignature[SHA1withECDSA]("SHA1withECDSA", "ECDSA")
       with ByteEV[SHA1withECDSA] {
+    @inline def is: Is[SHA1withECDSA, Array[Byte]] = SHA1withECDSA$$.is
 
     @inline def fromArray(array: Array[Byte]): SHA1withECDSA = SHA1withECDSA$$.is.flip.coerce(array)
 
@@ -203,6 +214,7 @@ package object imports {
   implicit object SHA224withECDSA
       extends GeneralSignature[SHA224withECDSA]("SHA224withECDSA", "ECDSA")
       with ByteEV[SHA224withECDSA] {
+    @inline def is: Is[SHA224withECDSA, Array[Byte]] = SHA224withECDSA$$.is
 
     @inline def fromArray(array: Array[Byte]): SHA224withECDSA = SHA224withECDSA$$.is.flip.coerce(array)
 
@@ -222,6 +234,7 @@ package object imports {
   implicit object SHA256withECDSA
       extends ECDSASignature[SHA256withECDSA]("SHA256withECDSA", "P-256", 64)
       with ByteEV[SHA256withECDSA] {
+    @inline def is: Is[SHA256withECDSA, Array[Byte]] = SHA256withECDSA$$.is
 
     @inline def fromArray(array: Array[Byte]): SHA256withECDSA = SHA256withECDSA$$.is.flip.coerce(array)
 
@@ -238,6 +251,7 @@ package object imports {
   implicit object SHA384withECDSA
       extends ECDSASignature[SHA384withECDSA]("SHA384withECDSA", "P-384", 96)
       with ByteEV[SHA384withECDSA] {
+    @inline def is: Is[SHA384withECDSA, Array[Byte]] = SHA384withECDSA$$.is
 
     @inline def fromArray(array: Array[Byte]): SHA384withECDSA = SHA384withECDSA$$.is.flip.coerce(array)
 
@@ -254,6 +268,7 @@ package object imports {
   implicit object SHA512withECDSA
       extends ECDSASignature[SHA512withECDSA]("SHA512withECDSA", "P-521", 132)
       with ByteEV[SHA512withECDSA] {
+    @inline def is: Is[SHA512withECDSA, Array[Byte]] = SHA512withECDSA$$.is
 
     @inline def fromArray(array: Array[Byte]): SHA512withECDSA = SHA512withECDSA$$.is.flip.coerce(array)
 


### PR DESCRIPTION
our `Is` instances should be public, so people don't run into the issues such as #55.

Ultimately, I think we do a pretty decent job in providing default constructors so people don't have to ever resort to using `Is` (i.e `apply` or `fromArray`), but they should be public for the sake of things that require a construction like doobie's `Meta`