### PR TITLE
use j.u.Arrays.fill because it might be faster

### DIFF
--- a/common/src/main/scala/tsec/common/ByteUtils.scala
+++ b/common/src/main/scala/tsec/common/ByteUtils.scala
@@ -3,26 +3,16 @@ package tsec.common
 import java.security.MessageDigest
 
 object ByteUtils {
-  private val zeroByte = 0.toByte
-  private val zeroChar = 0.toChar
 
-  def zeroByteArray(a: Array[Byte]): Unit = {
-    var i = 0
-    while (i < a.length) {
-      a(i) = zeroByte
-      i += 1
-    }
+  @inline def zeroByteArray(a: Array[Byte]): Unit = {
+    java.util.Arrays.fill(a, 0.toByte)
   }
 
-  def zeroCharArray(a: Array[Char]): Unit = {
-    var i = 0
-    while (i < a.length) {
-      a(i) = zeroChar
-      i += 1
-    }
+  @inline def zeroCharArray(a: Array[Char]): Unit = {
+    java.util.Arrays.fill(a, 0.toChar)
   }
 
-  def constantTimeEquals(a: Array[Byte], b: Array[Byte]): Boolean =
+  @inline def constantTimeEquals(a: Array[Byte], b: Array[Byte]): Boolean =
     MessageDigest.isEqual(a, b)
 
 }


### PR DESCRIPTION
I left these in the `ByteUtils` object b/c it's cheap with `@inline` and communicates intent better than calling `.fill(_, 0.toXXX)`.