### PR TITLE
remove useless optionTs

### DIFF
--- a/tsec-http4s/src/main/scala/tsec/authentication/AuthenticatorService.scala
+++ b/tsec-http4s/src/main/scala/tsec/authentication/AuthenticatorService.scala
@@ -1,6 +1,5 @@
 package tsec.authentication
 
-import cats.Applicative
 import cats.data.{Kleisli, NonEmptyList, OptionT}
 import cats.effect.Sync
 import org.http4s.{HttpService, Request, Response, Status}
@@ -48,35 +47,35 @@ abstract class AuthenticatorService[F[_]: Sync, I, V, A] {
     * @param body
     * @return
     */
-  def create(body: I): OptionT[F, A]
+  def create(body: I): F[A]
 
   /** Update the altered authenticator
     *
     * @param authenticator
     * @return
     */
-  def update(authenticator: A): OptionT[F, A]
+  def update(authenticator: A): F[A]
 
   /** Delete an authenticator from a backing store, or invalidate it.
     *
     * @param authenticator
     * @return
     */
-  def discard(authenticator: A): OptionT[F, A]
+  def discard(authenticator: A): F[A]
 
   /** Renew an authenticator: Reset it's expiry and whatnot.
     *
     * @param authenticator
     * @return
     */
-  def renew(authenticator: A): OptionT[F, A]
+  def renew(authenticator: A): F[A]
 
   /** Refresh an authenticator: Primarily used for sliding window expiration
     *
     * @param authenticator
     * @return
     */
-  def refresh(authenticator: A): OptionT[F, A]
+  def refresh(authenticator: A): F[A]
 
   /** Embed an authenticator directly into a response.
     * Particularly useful for adding an authenticator into unauthenticated actions

--- a/tsec-http4s/src/main/scala/tsec/authentication/BearerTokenAuthenticator.scala
+++ b/tsec-http4s/src/main/scala/tsec/authentication/BearerTokenAuthenticator.scala
@@ -50,7 +50,7 @@ object BearerTokenAuthenticator {
       private def validateAndRefresh(token: TSecBearerToken[I]): OptionT[F, TSecBearerToken[I]] =
         OptionT.liftF(F.delay(Instant.now())).flatMap { now =>
           if (!token.isExpired(now) && settings.maxIdle.forall(!token.isTimedOut(now, _)))
-            refresh(token)
+            OptionT.liftF(refresh(token))
           else
             OptionT.none
         }
@@ -64,8 +64,8 @@ object BearerTokenAuthenticator {
           identity  <- identityStore.get(token.identity)
         } yield SecuredRequest(request, identity, refreshed)
 
-      def create(body: I): OptionT[F, TSecBearerToken[I]] =
-        OptionT.liftF(for {
+      def create(body: I): F[TSecBearerToken[I]] =
+        for {
           now <- F.delay(Instant.now())
           newToken = TSecBearerToken(
             SecureRandomId.generate,
@@ -74,16 +74,16 @@ object BearerTokenAuthenticator {
             settings.maxIdle.map(_ => now)
           )
           out <- tokenStore.put(newToken)
-        } yield out)
+        } yield out
 
-      def update(authenticator: TSecBearerToken[I]): OptionT[F, TSecBearerToken[I]] =
-        OptionT.liftF(tokenStore.update(authenticator))
+      def update(authenticator: TSecBearerToken[I]): F[TSecBearerToken[I]] =
+        tokenStore.update(authenticator)
 
-      def discard(authenticator: TSecBearerToken[I]): OptionT[F, TSecBearerToken[I]] =
-        OptionT.liftF(tokenStore.delete(authenticator.id)).map(_ => authenticator)
+      def discard(authenticator: TSecBearerToken[I]): F[TSecBearerToken[I]] =
+        tokenStore.delete(authenticator.id).map(_ => authenticator)
 
-      def renew(authenticator: TSecBearerToken[I]): OptionT[F, TSecBearerToken[I]] =
-        OptionT.liftF(for {
+      def renew(authenticator: TSecBearerToken[I]): F[TSecBearerToken[I]] =
+        for {
           now <- F.delay(Instant.now())
           updated <- tokenStore.update(
             authenticator.copy(
@@ -91,16 +91,16 @@ object BearerTokenAuthenticator {
               lastTouched = settings.maxIdle.map(_ => now)
             )
           )
-        } yield updated)
+        } yield updated
 
-      def refresh(authenticator: TSecBearerToken[I]): OptionT[F, TSecBearerToken[I]] = settings.maxIdle match {
+      def refresh(authenticator: TSecBearerToken[I]): F[TSecBearerToken[I]] = settings.maxIdle match {
         case None =>
-          OptionT.pure(authenticator)
+          F.pure(authenticator)
         case Some(idleTime) =>
-          OptionT.liftF(for {
+          for {
             now     <- F.delay(Instant.now())
             updated <- tokenStore.update(authenticator.copy(lastTouched = Some(now.plusSeconds(idleTime.toSeconds))))
-          } yield updated)
+          } yield updated
       }
 
       def embed(response: Response[F], authenticator: TSecBearerToken[I]): Response[F] =

--- a/tsec-http4s/src/main/scala/tsec/authentication/EncryptedCookieAuthenticator.scala
+++ b/tsec-http4s/src/main/scala/tsec/authentication/EncryptedCookieAuthenticator.scala
@@ -223,7 +223,7 @@ object EncryptedCookieAuthenticator {
           raw: AEADCookie[A],
           now: Instant
       ): OptionT[F, AuthEncryptedCookie[A, I]] =
-        if (validateCookie(internal, raw, now)) refresh(internal) else OptionT.none
+        if (validateCookie(internal, raw, now)) OptionT.liftF(refresh(internal)) else OptionT.none
 
       def extractRawOption(request: Request[F]): Option[String] =
         unliftedCookieFromRequest(settings.cookieName, request).map(_.content)
@@ -242,8 +242,8 @@ object EncryptedCookieAuthenticator {
       /** Create a new cookie from the id field of a particular user.
         *
         */
-      def create(body: I): OptionT[F, AuthEncryptedCookie[A, I]] =
-        OptionT.liftF(for {
+      def create(body: I): F[AuthEncryptedCookie[A, I]] =
+        for {
           cookieId <- F.delay(UUID.randomUUID())
           now      <- F.delay(Instant.now())
           expiry      = now.plusSeconds(settings.expiryDuration.toSeconds)
@@ -252,25 +252,25 @@ object EncryptedCookieAuthenticator {
           encrypted <- F.fromEither(AEADCookieEncryptor.signAndEncrypt[A](messageBody, generateAAD(messageBody), key))
           cookie    <- F.pure(AuthEncryptedCookie.build[A, I](cookieId, encrypted, body, expiry, lastTouched, settings))
           _         <- tokenStore.put(cookie)
-        } yield cookie)
+        } yield cookie
 
       /** Update our authenticator in the backing store.
         *
         */
-      def update(authenticator: AuthEncryptedCookie[A, I]): OptionT[F, AuthEncryptedCookie[A, I]] =
-        OptionT.liftF(tokenStore.update(authenticator))
+      def update(authenticator: AuthEncryptedCookie[A, I]): F[AuthEncryptedCookie[A, I]] =
+        tokenStore.update(authenticator)
 
       /** Discard our authenticator from the backing store
         *
         */
-      def discard(authenticator: AuthEncryptedCookie[A, I]): OptionT[F, AuthEncryptedCookie[A, I]] =
-        OptionT.liftF(tokenStore.delete(authenticator.id)).map(_ => authenticator)
+      def discard(authenticator: AuthEncryptedCookie[A, I]): F[AuthEncryptedCookie[A, I]] =
+        tokenStore.delete(authenticator.id).map(_ => authenticator)
 
       /** Renew, aka reset both the expiry as well as the last touched (if present) value
         *
         */
-      def renew(authenticator: AuthEncryptedCookie[A, I]): OptionT[F, AuthEncryptedCookie[A, I]] =
-        OptionT.liftF(F.pure(Instant.now()).flatMap { now =>
+      def renew(authenticator: AuthEncryptedCookie[A, I]): F[AuthEncryptedCookie[A, I]] =
+        F.delay(Instant.now()).flatMap { now =>
           settings.maxIdle match {
             case Some(_) =>
               val updated = authenticator.copy[A, I](
@@ -284,27 +284,25 @@ object EncryptedCookieAuthenticator {
               )
               tokenStore.update(updated).map(_ => updated)
           }
-        })
+        }
 
       /** Touch our authenticator. Only used for sliding window expiration. Otherwise, it will be a no-op.
         *
         */
-      def refresh(authenticator: AuthEncryptedCookie[A, I]): OptionT[F, AuthEncryptedCookie[A, I]] =
+      def refresh(authenticator: AuthEncryptedCookie[A, I]): F[AuthEncryptedCookie[A, I]] =
         settings.maxIdle match {
           case Some(_) =>
-            OptionT.liftF(
-              F.delay(Instant.now())
-                .flatMap(
-                  now =>
-                    tokenStore.update(
-                      authenticator.copy[A, I](
-                        lastTouched = Some(now)
-                      )
-                  )
+            F.delay(Instant.now())
+              .flatMap(
+                now =>
+                  tokenStore.update(
+                    authenticator.copy[A, I](
+                      lastTouched = Some(now)
+                    )
                 )
-            )
+              )
           case None =>
-            OptionT.pure[F](authenticator)
+            F.pure(authenticator)
         }
 
       def embed(response: Response[F], authenticator: AuthEncryptedCookie[A, I]): Response[F] =
@@ -370,7 +368,7 @@ object EncryptedCookieAuthenticator {
           internal: AuthEncryptedCookie[A, I],
           now: Instant
       ): OptionT[F, AuthEncryptedCookie[A, I]] =
-        if (validateCookie(internal, now)) refresh(internal) else OptionT.none
+        if (validateCookie(internal, now)) OptionT.liftF(refresh(internal)) else OptionT.none
 
       def extractRawOption(request: Request[F]): Option[String] =
         unliftedCookieFromRequest(settings.cookieName, request).map(_.content)
@@ -393,15 +391,15 @@ object EncryptedCookieAuthenticator {
         * Thus, we unfortunately have to encrypt the expiry data as well
         *
         */
-      def create(body: I): OptionT[F, AuthEncryptedCookie[A, I]] =
-        OptionT.liftF(for {
+      def create(body: I): F[AuthEncryptedCookie[A, I]] =
+        for {
           cookieId <- F.delay(UUID.randomUUID())
           now      <- F.delay(Instant.now())
           expiry      = now.plusSeconds(settings.expiryDuration.toSeconds)
           lastTouched = settings.maxIdle.map(_ => now)
           messageBody = AuthEncryptedCookie.Internal(cookieId, body, expiry, lastTouched).asJson.pretty(JWTPrinter)
           encrypted <- F.fromEither(AEADCookieEncryptor.signAndEncrypt[A](messageBody, generateAAD(messageBody), key))
-        } yield AuthEncryptedCookie.build[A, I](cookieId, encrypted, body, expiry, lastTouched, settings))
+        } yield AuthEncryptedCookie.build[A, I](cookieId, encrypted, body, expiry, lastTouched, settings)
 
       /** Reader's note:
         * Since this is a stateless authenticator, update must carry information about expiry and sliding window info
@@ -409,15 +407,13 @@ object EncryptedCookieAuthenticator {
         *
         * We sincerely don't want this, thus renew and refresh also rely on update.
         * */
-      def update(authenticator: AuthEncryptedCookie[A, I]): OptionT[F, AuthEncryptedCookie[A, I]] = {
+      def update(authenticator: AuthEncryptedCookie[A, I]): F[AuthEncryptedCookie[A, I]] = {
         val serialized = AuthEncryptedCookie
           .Internal(authenticator.id, authenticator.identity, authenticator.expiry, authenticator.lastTouched)
           .asJson
           .pretty(JWTPrinter)
         for {
-          encrypted <- OptionT.liftF(
-            F.fromEither(AEADCookieEncryptor.signAndEncrypt[A](serialized, generateAAD(serialized), key))
-          )
+          encrypted <- F.fromEither(AEADCookieEncryptor.signAndEncrypt[A](serialized, generateAAD(serialized), key))
         } yield authenticator.copy[A, I](content = encrypted)
       }
 
@@ -427,18 +423,16 @@ object EncryptedCookieAuthenticator {
         * @param authenticator
         * @return
         */
-      def discard(authenticator: AuthEncryptedCookie[A, I]): OptionT[F, AuthEncryptedCookie[A, I]] =
-        OptionT.liftF(
-          F.delay(Instant.now())
-            .map(now => authenticator.copy[A, I](content = AEADCookie[A]("invalid"), expiry = now))
-        )
+      def discard(authenticator: AuthEncryptedCookie[A, I]): F[AuthEncryptedCookie[A, I]] =
+        F.delay(Instant.now())
+          .map(now => authenticator.copy[A, I](content = AEADCookie[A]("invalid"), expiry = now))
 
       /** Renew all of our cookie's possible expirations.
         * If there is a timeout, refresh that as well. otherwise, simply update the expiry.
         *
         */
-      def renew(authenticator: AuthEncryptedCookie[A, I]): OptionT[F, AuthEncryptedCookie[A, I]] =
-        OptionT.liftF(F.delay(Instant.now())).flatMap { now =>
+      def renew(authenticator: AuthEncryptedCookie[A, I]): F[AuthEncryptedCookie[A, I]] =
+        F.delay(Instant.now()).flatMap { now =>
           settings.maxIdle match {
             case Some(idleTime) =>
               update(
@@ -456,20 +450,17 @@ object EncryptedCookieAuthenticator {
           }
         }
 
-      def refresh(authenticator: AuthEncryptedCookie[A, I]): OptionT[F, AuthEncryptedCookie[A, I]] =
+      def refresh(authenticator: AuthEncryptedCookie[A, I]): F[AuthEncryptedCookie[A, I]] =
         settings.maxIdle match {
           case Some(_) =>
-            OptionT
-              .liftF(
-                F.delay(
-                  authenticator.copy[A, I](
-                    lastTouched = Some(Instant.now())
-                  )
+            F.delay(
+                authenticator.copy[A, I](
+                  lastTouched = Some(Instant.now())
                 )
               )
               .flatMap(update)
           case None =>
-            OptionT.pure[F](authenticator)
+            F.pure(authenticator)
         }
 
       def embed(response: Response[F], authenticator: AuthEncryptedCookie[A, I]): Response[F] =

--- a/tsec-http4s/src/main/scala/tsec/authentication/JWTAuthenticator.scala
+++ b/tsec-http4s/src/main/scala/tsec/authentication/JWTAuthenticator.scala
@@ -111,7 +111,7 @@ object JWTAuthenticator {
           now: Instant
       ): OptionT[F, AugmentedJWT[A, I]] =
         if (verifyWithRaw(raw, retrieved, now))
-          refresh(retrieved)
+          OptionT.liftF(refresh(retrieved))
         else
           OptionT.none
 
@@ -127,8 +127,8 @@ object JWTAuthenticator {
           identity  <- identityStore.get(retrieved.identity)
         } yield SecuredRequest(request, identity, refreshed)
 
-      def create(body: I): OptionT[F, AugmentedJWT[A, I]] =
-        OptionT.liftF(for {
+      def create(body: I): F[AugmentedJWT[A, I]] =
+        for {
           cookieId <- F.delay(SecureRandomId.generate)
           now      <- F.delay(Instant.now())
           expiry      = now.plusSeconds(expiryDuration.toSeconds)
@@ -140,38 +140,35 @@ object JWTAuthenticator {
           )
           signed  <- JWTMac.build[F, A](claims, signingKey)
           created <- tokenStore.put(AugmentedJWT(cookieId, signed, body, expiry, lastTouched))
-        } yield created)
+        } yield created
 
-      def update(authenticator: AugmentedJWT[A, I]): OptionT[F, AugmentedJWT[A, I]] =
-        OptionT.liftF(tokenStore.update(authenticator))
+      def update(authenticator: AugmentedJWT[A, I]): F[AugmentedJWT[A, I]] =
+        tokenStore.update(authenticator)
 
-      def discard(authenticator: AugmentedJWT[A, I]): OptionT[F, AugmentedJWT[A, I]] =
-        OptionT.liftF(tokenStore.delete(SecureRandomId.coerce(authenticator.id))).map(_ => authenticator)
+      def discard(authenticator: AugmentedJWT[A, I]): F[AugmentedJWT[A, I]] =
+        tokenStore.delete(SecureRandomId.coerce(authenticator.id)).map(_ => authenticator)
 
-      def renew(authenticator: AugmentedJWT[A, I]): OptionT[F, AugmentedJWT[A, I]] =
-        OptionT
-          .liftF(F.delay(Instant.now()).flatMap { now =>
-            val updatedExpiry = now.plusSeconds(expiryDuration.toSeconds)
-            val newBody       = authenticator.jwt.body.copy(expiration = Some(updatedExpiry.getEpochSecond))
-            maxIdle match {
-              case Some(idleTime) =>
-                for {
-                  reSigned <- JWTMac.build(newBody, signingKey)
-                  updated <- tokenStore
-                    .update(authenticator.copy(jwt = reSigned, expiry = updatedExpiry, lastTouched = Some(now)))
-                } yield updated
-              case None =>
-                for {
-                  reSigned <- JWTMac.build(newBody, signingKey)
-                  updated  <- tokenStore.update(authenticator.copy(jwt = reSigned, expiry = updatedExpiry))
-                } yield updated
-            }
-          })
-          .handleErrorWith(_ => OptionT.none)
+      def renew(authenticator: AugmentedJWT[A, I]): F[AugmentedJWT[A, I]] =
+        F.delay(Instant.now()).flatMap { now =>
+          val updatedExpiry = now.plusSeconds(expiryDuration.toSeconds)
+          val newBody       = authenticator.jwt.body.copy(expiration = Some(updatedExpiry.getEpochSecond))
+          maxIdle match {
+            case Some(idleTime) =>
+              for {
+                reSigned <- JWTMac.build(newBody, signingKey)
+                updated <- tokenStore
+                  .update(authenticator.copy(jwt = reSigned, expiry = updatedExpiry, lastTouched = Some(now)))
+              } yield updated
+            case None =>
+              for {
+                reSigned <- JWTMac.build(newBody, signingKey)
+                updated  <- tokenStore.update(authenticator.copy(jwt = reSigned, expiry = updatedExpiry))
+              } yield updated
+          }
+        }
 
-      def refresh(authenticator: AugmentedJWT[A, I]): OptionT[F, AugmentedJWT[A, I]] =
-        OptionT
-          .liftF(F.delay(Instant.now()).flatMap { now =>
+      def refresh(authenticator: AugmentedJWT[A, I]): F[AugmentedJWT[A, I]] =
+        F.delay(Instant.now()).flatMap { now =>
             maxIdle match {
               case Some(idleTime) =>
                 val updated = authenticator.copy(lastTouched = Some(now))
@@ -179,8 +176,7 @@ object JWTAuthenticator {
               case None =>
                 F.pure(authenticator)
             }
-          })
-          .handleErrorWith(_ => OptionT.none[F, AugmentedJWT[A, I]])
+          }
 
       def embed(response: Response[F], authenticator: AugmentedJWT[A, I]): Response[F] =
         response.putHeaders(
@@ -245,7 +241,7 @@ object JWTAuthenticator {
           now: Instant
       ): OptionT[F, AugmentedJWT[A, I]] =
         if (verifyWithRaw(raw, retrieved, now))
-          refresh(retrieved)
+          OptionT.liftF(refresh(retrieved))
         else
           OptionT.none
 
@@ -261,8 +257,8 @@ object JWTAuthenticator {
           identity  <- identityStore.get(retrieved.identity)
         } yield SecuredRequest(request, identity, refreshed)
 
-      def create(body: I): OptionT[F, AugmentedJWT[A, I]] =
-        OptionT.liftF(for {
+      def create(body: I): F[AugmentedJWT[A, I]] =
+        for {
           cookieId <- F.delay(SecureRandomId.generate)
           now      <- F.delay(Instant.now())
           expiry      = now.plusSeconds(settings.expiryDuration.toSeconds)
@@ -273,17 +269,16 @@ object JWTAuthenticator {
           )
           signed  <- JWTMac.build[F, A](claims, signingKey)
           created <- tokenStore.put(AugmentedJWT(cookieId, signed, body, expiry, lastTouched))
-        } yield created)
+        } yield created
 
-      def update(authenticator: AugmentedJWT[A, I]): OptionT[F, AugmentedJWT[A, I]] =
-        OptionT.liftF(tokenStore.update(authenticator))
+      def update(authenticator: AugmentedJWT[A, I]): F[AugmentedJWT[A, I]] =
+        tokenStore.update(authenticator)
 
-      def discard(authenticator: AugmentedJWT[A, I]): OptionT[F, AugmentedJWT[A, I]] =
-        OptionT.liftF(tokenStore.delete(SecureRandomId.coerce(authenticator.id))).map(_ => authenticator)
+      def discard(authenticator: AugmentedJWT[A, I]): F[AugmentedJWT[A, I]] =
+        tokenStore.delete(SecureRandomId.coerce(authenticator.id)).map(_ => authenticator)
 
-      def renew(authenticator: AugmentedJWT[A, I]): OptionT[F, AugmentedJWT[A, I]] =
-        OptionT
-          .liftF(F.delay(Instant.now()).flatMap { now =>
+      def renew(authenticator: AugmentedJWT[A, I]): F[AugmentedJWT[A, I]] =
+        F.delay(Instant.now()).flatMap { now =>
             val updatedExpiry = now.plusSeconds(settings.expiryDuration.toSeconds)
             val newBody       = authenticator.jwt.body.copy(expiration = Some(updatedExpiry.getEpochSecond))
             settings.maxIdle match {
@@ -299,19 +294,18 @@ object JWTAuthenticator {
                   updated  <- tokenStore.update(authenticator.copy(jwt = reSigned, expiry = updatedExpiry))
                 } yield updated
             }
-          })
-          .handleErrorWith(_ => OptionT.none)
+          }
 
-      def refresh(authenticator: AugmentedJWT[A, I]): OptionT[F, AugmentedJWT[A, I]] =
+      def refresh(authenticator: AugmentedJWT[A, I]): F[AugmentedJWT[A, I]] =
         settings.maxIdle match {
           case Some(idleTime) =>
-            OptionT.liftF(for {
+            for {
               n <- F.delay(Instant.now())
               u = authenticator.copy(lastTouched = Some(n))
               updated <- tokenStore.update(u)
-            } yield updated)
+            } yield updated
           case None =>
-            OptionT.pure(authenticator)
+           F.pure(authenticator)
         }
 
       def embed(response: Response[F], authenticator: AugmentedJWT[A, I]): Response[F] =
@@ -397,12 +391,12 @@ object JWTAuthenticator {
             Instant.ofEpochSecond(expiry),
             lastTouched
           )
-          refreshed <- refresh(augmented)
+          refreshed <- OptionT.liftF(refresh(augmented))
           identity  <- identityStore.get(id)
         } yield SecuredRequest(request, identity, refreshed)
 
-      def create(body: I): OptionT[F, AugmentedJWT[A, I]] =
-        OptionT.liftF(for {
+      def create(body: I): F[AugmentedJWT[A, I]] =
+        for {
           now      <- F.delay(Instant.now())
           cookieId <- F.delay(SecureRandomId.generate)
           expiryTime  = now.plusSeconds(expiry.toSeconds)
@@ -415,15 +409,14 @@ object JWTAuthenticator {
             expiration = Some(expiryTime.getEpochSecond),
           )
           out <- JWTMac.build[F, A](claims, signingKey)
-        } yield AugmentedJWT(cookieId, out, body, expiryTime, lastTouched))
+        } yield AugmentedJWT(cookieId, out, body, expiryTime, lastTouched)
 
-      def update(authenticator: AugmentedJWT[A, I]): OptionT[F, AugmentedJWT[A, I]] =
-        OptionT.pure[F](authenticator)
+      def update(authenticator: AugmentedJWT[A, I]): F[AugmentedJWT[A, I]] =
+        F.pure(authenticator)
 
       /** The only "discarding" we can do to a stateless token is make it invalid. */
-      def discard(authenticator: AugmentedJWT[A, I]): OptionT[F, AugmentedJWT[A, I]] =
-        OptionT
-          .liftF(for {
+      def discard(authenticator: AugmentedJWT[A, I]): F[AugmentedJWT[A, I]] =
+        for {
             now <- F.delay(Instant.now)
             jwt <- JWTMac.build(
               authenticator.jwt.body.copy(
@@ -433,12 +426,10 @@ object JWTAuthenticator {
               ),
               signingKey
             )
-          } yield AugmentedJWT(authenticator.id, jwt, authenticator.identity, now, authenticator.lastTouched))
-          .handleErrorWith(_ => OptionT.none)
+          } yield AugmentedJWT(authenticator.id, jwt, authenticator.identity, now, authenticator.lastTouched)
 
-      def renew(authenticator: AugmentedJWT[A, I]): OptionT[F, AugmentedJWT[A, I]] =
-        OptionT
-          .liftF(for {
+      def renew(authenticator: AugmentedJWT[A, I]): F[AugmentedJWT[A, I]] =
+        for {
             now <- F.delay(Instant.now())
             updatedExpiry = now.plusSeconds(expiry.toSeconds)
             authBody      = authenticator.jwt.body
@@ -452,19 +443,16 @@ object JWTAuthenticator {
               case None =>
                 AugmentedJWT(authenticator.id, jwt, authenticator.identity, updatedExpiry, None)
             }
-          } yield aug)
-          .handleErrorWith(_ => OptionT.none)
+          } yield aug
 
-      def refresh(authenticator: AugmentedJWT[A, I]): OptionT[F, AugmentedJWT[A, I]] = maxIdle match {
+      def refresh(authenticator: AugmentedJWT[A, I]): F[AugmentedJWT[A, I]] = maxIdle match {
         case Some(_) =>
-          OptionT
-            .liftF(for {
+         for {
               now      <- F.delay(Instant.now())
               newToken <- JWTMac.build(authenticator.jwt.body.copy(issuedAt = Some(now.getEpochSecond)), signingKey)
-            } yield authenticator.copy(jwt = newToken, lastTouched = Some(now)))
-            .handleErrorWith(_ => OptionT.none)
+            } yield authenticator.copy(jwt = newToken, lastTouched = Some(now))
         case None =>
-          OptionT.pure[F](authenticator)
+          F.pure(authenticator)
       }
 
       def embed(response: Response[F], authenticator: AugmentedJWT[A, I]): Response[F] =
@@ -536,7 +524,7 @@ object JWTAuthenticator {
         */
       private def encryptIdentity(body: I, lastTouched: Option[Instant]): Either[CipherError, String] =
         for {
-          instance <- enc.instance
+          instance <- enc.instance //Todo: this is awful, screw either
           encrypted <- instance.encrypt(
             PlainText(body.asJson.pretty(JWTPrinter).utf8Bytes),
             encryptionKey
@@ -551,7 +539,7 @@ object JWTAuthenticator {
         * @return
         */
       private def decryptIdentity(body: String, instance: EncryptorInstance[E]): F[I] =
-        F.fromEither(for {
+        F.fromEither(for { //Todo: god why
           cipherText <- enc.fromSingleArray(body.base64Bytes)
           decrypted  <- instance.decrypt(cipherText, encryptionKey)
           decoded    <- decode[I](decrypted.content.toUtf8String)
@@ -571,7 +559,7 @@ object JWTAuthenticator {
 
       def parseRaw(raw: String, request: Request[F]): OptionT[F, SecuredRequest[F, V, AugmentedJWT[A, I]]] =
         for {
-          eInstance   <- OptionT.liftF(F.fromEither(enc.instance))
+          eInstance   <- OptionT.liftF(F.fromEither(enc.instance)) // Todo: pls my heart
           now         <- OptionT.liftF(F.delay(Instant.now))
           extracted   <- OptionT.liftF(cv.verifyAndParse(raw, signingKey, now))
           rawId       <- OptionT.fromOption[F](extracted.body.subject)
@@ -585,12 +573,12 @@ object JWTAuthenticator {
             Instant.ofEpochSecond(expiry),
             lastTouched
           )
-          refreshed <- refresh(augmented)
+          refreshed <- OptionT.liftF(refresh(augmented))
           identity  <- identityStore.get(decodedBody)
         } yield SecuredRequest(request, identity, refreshed)
 
-      def create(body: I): OptionT[F, AugmentedJWT[A, I]] =
-        OptionT.liftF(for {
+      def create(body: I): F[AugmentedJWT[A, I]] =
+        for {
           cookieId <- F.delay(SecureRandomId.generate)
           now      <- F.delay(Instant.now())
           expiry      = now.plusSeconds(expiryDuration.toSeconds)
@@ -603,14 +591,14 @@ object JWTAuthenticator {
             expiration = Some(expiry.getEpochSecond),
           )
           jwt <- JWTMac.build[F, A](claims, signingKey)
-        } yield AugmentedJWT(cookieId, jwt, body, expiry, lastTouched))
+        } yield AugmentedJWT(cookieId, jwt, body, expiry, lastTouched)
 
-      def update(authenticator: AugmentedJWT[A, I]): OptionT[F, AugmentedJWT[A, I]] =
-        OptionT.pure[F](authenticator)
+      def update(authenticator: AugmentedJWT[A, I]): F[AugmentedJWT[A, I]] =
+        F.pure(authenticator)
 
       /** The only "discarding" we can do to a stateless token is make it invalid. */
-      def discard(authenticator: AugmentedJWT[A, I]): OptionT[F, AugmentedJWT[A, I]] =
-        OptionT.liftF(for {
+      def discard(authenticator: AugmentedJWT[A, I]): F[AugmentedJWT[A, I]] =
+        for {
           now <- F.delay(Instant.now())
           jwt <- JWTMac.build(
             authenticator.jwt.body.copy(
@@ -620,11 +608,10 @@ object JWTAuthenticator {
             ),
             signingKey
           )
-        } yield AugmentedJWT(authenticator.id, jwt, authenticator.identity, now, authenticator.lastTouched))
+        } yield AugmentedJWT(authenticator.id, jwt, authenticator.identity, now, authenticator.lastTouched)
 
-      def renew(authenticator: AugmentedJWT[A, I]): OptionT[F, AugmentedJWT[A, I]] =
-        OptionT
-          .liftF(F.delay(Instant.now()).flatMap { now =>
+      def renew(authenticator: AugmentedJWT[A, I]): F[AugmentedJWT[A, I]] =
+        F.delay(Instant.now()).flatMap { now =>
             val updatedExpiry = now.plusSeconds(expiryDuration.toSeconds)
             maxIdle match {
               case Some(_) =>
@@ -640,18 +627,17 @@ object JWTAuthenticator {
                   .build(authenticator.jwt.body.copy(expiration = Some(updatedExpiry.getEpochSecond)), signingKey)
                   .map(AugmentedJWT(authenticator.id, _, authenticator.identity, updatedExpiry, None))
             }
-          })
-          .handleErrorWith(_ => OptionT.none)
+          }
 
-      def refresh(authenticator: AugmentedJWT[A, I]): OptionT[F, AugmentedJWT[A, I]] = maxIdle match {
+      def refresh(authenticator: AugmentedJWT[A, I]): F[AugmentedJWT[A, I]] = maxIdle match {
         case Some(_) =>
-          OptionT.liftF(for {
+          for {
             now <- F.delay(Instant.now())
             jwt <- JWTMac.build(authenticator.jwt.body.copy(issuedAt = Some(now.getEpochSecond)), signingKey)
-          } yield authenticator.copy(jwt = jwt, lastTouched = Some(now)))
+          } yield authenticator.copy(jwt = jwt, lastTouched = Some(now))
 
         case None =>
-          OptionT.pure[F](authenticator)
+          F.pure(authenticator)
       }
 
       def embed(response: Response[F], authenticator: AugmentedJWT[A, I]): Response[F] =
@@ -751,12 +737,12 @@ object JWTAuthenticator {
             Instant.ofEpochSecond(expiry),
             lastTouched
           )
-          refreshed <- refresh(augmented)
+          refreshed <- OptionT.liftF(refresh(augmented))
           identity  <- identityStore.get(decodedBody)
         } yield SecuredRequest(request, identity, refreshed)
 
-      def create(body: I): OptionT[F, AugmentedJWT[A, I]] =
-        OptionT.liftF(for {
+      def create(body: I): F[AugmentedJWT[A, I]] =
+        for {
           now      <- F.delay(Instant.now())
           cookieId <- F.delay(SecureRandomId.generate)
           expiry      = now.plusSeconds(settings.expiryDuration.toSeconds)
@@ -770,16 +756,15 @@ object JWTAuthenticator {
           )
           newToken <- JWTMac.build[F, A](claims, signingKey)
 
-        } yield AugmentedJWT(cookieId, newToken, body, expiry, lastTouched))
+        } yield AugmentedJWT(cookieId, newToken, body, expiry, lastTouched)
 
       /** Pretty much a no-op for a stateless token **/
-      def update(authenticator: AugmentedJWT[A, I]): OptionT[F, AugmentedJWT[A, I]] =
-        OptionT.pure[F](authenticator)
+      def update(authenticator: AugmentedJWT[A, I]): F[AugmentedJWT[A, I]] =
+        F.pure(authenticator)
 
       /** The only "discarding" we can do to a stateless token is make it invalid. **/
-      def discard(authenticator: AugmentedJWT[A, I]): OptionT[F, AugmentedJWT[A, I]] =
-        OptionT
-          .liftF(for {
+      def discard(authenticator: AugmentedJWT[A, I]): F[AugmentedJWT[A, I]] =
+        for {
             now <- F.delay(Instant.now())
             jwt <- JWTMac.build(
               authenticator.jwt.body.copy(
@@ -789,12 +774,10 @@ object JWTAuthenticator {
               ),
               signingKey
             )
-          } yield AugmentedJWT(authenticator.id, jwt, authenticator.identity, now, authenticator.lastTouched))
-          .handleErrorWith(_ => OptionT.none)
+          } yield AugmentedJWT(authenticator.id, jwt, authenticator.identity, now, authenticator.lastTouched)
 
-      def renew(authenticator: AugmentedJWT[A, I]): OptionT[F, AugmentedJWT[A, I]] =
-        OptionT
-          .liftF(F.delay(Instant.now()).flatMap { now =>
+      def renew(authenticator: AugmentedJWT[A, I]): F[AugmentedJWT[A, I]] =
+       F.delay(Instant.now()).flatMap { now =>
             val updatedExpiry = now.plusSeconds(settings.expiryDuration.toSeconds)
             settings.maxIdle match {
               case Some(idleTime) =>
@@ -810,19 +793,16 @@ object JWTAuthenticator {
                   .build(authenticator.jwt.body.copy(expiration = Some(updatedExpiry.getEpochSecond)), signingKey)
                   .map(AugmentedJWT(authenticator.id, _, authenticator.identity, updatedExpiry, None))
             }
-          })
-          .handleErrorWith(_ => OptionT.none)
+          }
 
-      def refresh(authenticator: AugmentedJWT[A, I]): OptionT[F, AugmentedJWT[A, I]] = settings.maxIdle match {
+      def refresh(authenticator: AugmentedJWT[A, I]): F[AugmentedJWT[A, I]] = settings.maxIdle match {
         case Some(_) =>
-          OptionT
-            .liftF(for {
+          for {
               now      <- F.delay(Instant.now())
               newToken <- JWTMac.build(authenticator.jwt.body.copy(issuedAt = Some(now.getEpochSecond)), signingKey)
-            } yield authenticator.copy(jwt = newToken, lastTouched = Some(now)))
-            .handleErrorWith(_ => OptionT.none)
+            } yield authenticator.copy(jwt = newToken, lastTouched = Some(now))
         case None =>
-          OptionT.pure[F](authenticator)
+          F.pure(authenticator)
       }
 
       def embed(response: Response[F], authenticator: AugmentedJWT[A, I]): Response[F] =

--- a/tsec-http4s/src/test/scala/tsec/authentication/AuthCompositionSpec.scala
+++ b/tsec-http4s/src/test/scala/tsec/authentication/AuthCompositionSpec.scala
@@ -61,7 +61,7 @@ class AuthCompositionSpec extends AuthenticatorSpec {
 
     val g = for {
       _       <- OptionT.liftF(dummyStore.put(DummyUser(1)))
-      created <- jwtAuthenticator.create(1)
+      created <- OptionT.liftF(jwtAuthenticator.create(1))
       r <- folded.run(
         Request[IO]().putHeaders(Header(jwtSettings.headerName, JWTMac.toEncodedString[IO, HMACSHA256](created.jwt)))
       )
@@ -73,7 +73,7 @@ class AuthCompositionSpec extends AuthenticatorSpec {
   it should "work for the second authenticator" in {
 
     val g = for {
-      created <- bearerTokenAuthenticator.create(1)
+      created <- OptionT.liftF(bearerTokenAuthenticator.create(1))
       r       <- folded.run(Request[IO]().putHeaders(H4SA(Credentials.Token(AuthScheme.Bearer, created.id))))
     } yield r
 
@@ -83,7 +83,7 @@ class AuthCompositionSpec extends AuthenticatorSpec {
   it should "work for the third authenticator" in {
 
     val g = for {
-      created <- cookieAuthenticator.create(1)
+      created <- OptionT.liftF(cookieAuthenticator.create(1))
       r       <- folded.run(Request[IO]().addCookie(created.toCookie))
     } yield r
 

--- a/tsec-http4s/src/test/scala/tsec/authentication/BearerTokenAuthenticatorTests.scala
+++ b/tsec-http4s/src/test/scala/tsec/authentication/BearerTokenAuthenticatorTests.scala
@@ -23,14 +23,14 @@ class BearerTokenAuthenticatorTests extends RequestAuthenticatorSpec {
       def embedInRequest(request: Request[IO], authenticator: TSecBearerToken[Int]): Request[IO] =
         request.putHeaders(Authorization(Credentials.Token(AuthScheme.Bearer, authenticator.id)))
 
-      def expireAuthenticator(b: TSecBearerToken[Int]): OptionT[IO, TSecBearerToken[Int]] =
+      def expireAuthenticator(b: TSecBearerToken[Int]): IO[TSecBearerToken[Int]] =
         authenticator.update(b.copy(expiry = Instant.now.minusSeconds(30)))
 
-      def timeoutAuthenticator(b: TSecBearerToken[Int]): OptionT[IO, TSecBearerToken[Int]] =
+      def timeoutAuthenticator(b: TSecBearerToken[Int]): IO[TSecBearerToken[Int]] =
         authenticator.update(b.copy(lastTouched = Some(Instant.now.minusSeconds(300000))))
 
-      def wrongKeyAuthenticator: OptionT[IO, TSecBearerToken[Int]] =
-        OptionT.pure(TSecBearerToken(SecureRandomId.generate, -20, Instant.now(), None))
+      def wrongKeyAuthenticator: IO[TSecBearerToken[Int]] =
+        IO.pure(TSecBearerToken(SecureRandomId.generate, -20, Instant.now(), None))
     }
   }
 

--- a/tsec-http4s/src/test/scala/tsec/authentication/EncryptedCookieAuthenticatorSpec.scala
+++ b/tsec-http4s/src/test/scala/tsec/authentication/EncryptedCookieAuthenticatorSpec.scala
@@ -35,19 +35,19 @@ class EncryptedCookieAuthenticatorSpec extends RequestAuthenticatorSpec {
       def embedInRequest(request: Request[IO], authenticator: AuthEncryptedCookie[A, Int]): Request[IO] =
         request.addCookie(authenticator.toCookie)
 
-      def expireAuthenticator(b: AuthEncryptedCookie[A, Int]): OptionT[IO, AuthEncryptedCookie[A, Int]] = {
+      def expireAuthenticator(b: AuthEncryptedCookie[A, Int]): IO[AuthEncryptedCookie[A, Int]] = {
         val now     = Instant.now()
         val updated = b.copy[A, Int](expiry = now.minusSeconds(2000))
-        OptionT.liftF(store.update(updated)).map(_ => updated)
+        store.update(updated).map(_ => updated)
       }
 
-      def timeoutAuthenticator(b: AuthEncryptedCookie[A, Int]): OptionT[IO, AuthEncryptedCookie[A, Int]] = {
+      def timeoutAuthenticator(b: AuthEncryptedCookie[A, Int]): IO[AuthEncryptedCookie[A, Int]] = {
         val now     = Instant.now()
         val updated = b.copy[A, Int](lastTouched = Some(now.minusSeconds(2000)))
-        OptionT.liftF(store.update(updated)).map(_ => updated)
+        store.update(updated).map(_ => updated)
       }
 
-      def wrongKeyAuthenticator: OptionT[IO, AuthEncryptedCookie[A, Int]] =
+      def wrongKeyAuthenticator: IO[AuthEncryptedCookie[A, Int]] =
         EncryptedCookieAuthenticator
           .withBackingStore[IO, Int, DummyUser, A](
             TSecCookieSettings(cookieName, false, expiryDuration = 10.minutes, maxIdle = Some(10.minutes)),
@@ -96,19 +96,19 @@ class EncryptedCookieAuthenticatorSpec extends RequestAuthenticatorSpec {
         }
       }
 
-      def expireAuthenticator(b: AuthEncryptedCookie[A, Int]): OptionT[IO, AuthEncryptedCookie[A, Int]] = {
+      def expireAuthenticator(b: AuthEncryptedCookie[A, Int]): IO[AuthEncryptedCookie[A, Int]] = {
         val now     = Instant.now()
         val updated = b.copy[A, Int](expiry = now.minusSeconds(2000))
         auth.update(updated)
       }
 
-      def timeoutAuthenticator(b: AuthEncryptedCookie[A, Int]): OptionT[IO, AuthEncryptedCookie[A, Int]] = {
+      def timeoutAuthenticator(b: AuthEncryptedCookie[A, Int]): IO[AuthEncryptedCookie[A, Int]] = {
         val now     = Instant.now()
         val updated = b.copy[A, Int](lastTouched = Some(now.minusSeconds(2000)))
         auth.update(updated)
       }
 
-      def wrongKeyAuthenticator: OptionT[IO, AuthEncryptedCookie[A, Int]] =
+      def wrongKeyAuthenticator: IO[AuthEncryptedCookie[A, Int]] =
         EncryptedCookieAuthenticator
           .stateless[IO, Int, DummyUser, A](
             TSecCookieSettings(cookieName, false, expiryDuration = 10.minutes, maxIdle = Some(10.minutes)),

--- a/tsec-http4s/src/test/scala/tsec/authentication/RequestAuthenticatorSpec.scala
+++ b/tsec-http4s/src/test/scala/tsec/authentication/RequestAuthenticatorSpec.scala
@@ -46,7 +46,7 @@ class RequestAuthenticatorSpec extends AuthenticatorSpec {
     it should "TryExtractRaw properly" in {
 
       val response: OptionT[IO, Option[String]] = for {
-        auth <- requestAuth.authenticator.create(dummyBob.id)
+        auth <- OptionT.liftF(requestAuth.authenticator.create(dummyBob.id))
         embedded = authSpec.embedInRequest(Request[IO](uri = Uri.unsafeFromString("/api")), auth)
       } yield authSpec.auth.extractRawOption(embedded)
       response
@@ -58,7 +58,7 @@ class RequestAuthenticatorSpec extends AuthenticatorSpec {
     it should "Return a proper deserialized user" in {
 
       val response: OptionT[IO, Response[IO]] = for {
-        auth <- requestAuth.authenticator.create(dummyBob.id)
+        auth <- OptionT.liftF(requestAuth.authenticator.create(dummyBob.id))
         embedded = authSpec.embedInRequest(Request[IO](uri = Uri.unsafeFromString("/api")), auth)
         res <- testService(embedded)
       } yield res
@@ -70,8 +70,8 @@ class RequestAuthenticatorSpec extends AuthenticatorSpec {
 
     it should "fail on an expired token" in {
       val response: OptionT[IO, Response[IO]] = for {
-        auth    <- requestAuth.authenticator.create(dummyBob.id)
-        expired <- authSpec.expireAuthenticator(auth)
+        auth    <- OptionT.liftF(requestAuth.authenticator.create(dummyBob.id))
+        expired <- OptionT.liftF(authSpec.expireAuthenticator(auth))
         embedded = authSpec.embedInRequest(Request[IO](uri = Uri.unsafeFromString("/api")), expired)
         res <- testService(embedded)
       } yield res
@@ -84,9 +84,9 @@ class RequestAuthenticatorSpec extends AuthenticatorSpec {
     it should "work on a renewed token" in {
 
       val response: OptionT[IO, Response[IO]] = for {
-        auth    <- requestAuth.authenticator.create(dummyBob.id)
-        expired <- authSpec.expireAuthenticator(auth)
-        renewed <- authSpec.auth.renew(expired)
+        auth    <- OptionT.liftF(requestAuth.authenticator.create(dummyBob.id))
+        expired <- OptionT.liftF(authSpec.expireAuthenticator(auth))
+        renewed <- OptionT.liftF(authSpec.auth.renew(expired))
         embedded = authSpec.embedInRequest(Request[IO](uri = Uri.unsafeFromString("/api")), renewed)
         res <- testService(embedded)
       } yield res
@@ -98,8 +98,8 @@ class RequestAuthenticatorSpec extends AuthenticatorSpec {
 
     it should "fail on a timed out token" in {
       val response: OptionT[IO, Response[IO]] = for {
-        auth     <- requestAuth.authenticator.create(dummyBob.id)
-        timedOut <- authSpec.timeoutAuthenticator(auth)
+        auth     <- OptionT.liftF(requestAuth.authenticator.create(dummyBob.id))
+        timedOut <- OptionT.liftF(authSpec.timeoutAuthenticator(auth))
         embedded = authSpec.embedInRequest(Request[IO](uri = Uri.unsafeFromString("/api")), timedOut)
         res <- testService(embedded)
       } yield res
@@ -112,9 +112,9 @@ class RequestAuthenticatorSpec extends AuthenticatorSpec {
     it should "work on a refreshed token" in {
 
       val response: OptionT[IO, Response[IO]] = for {
-        auth    <- requestAuth.authenticator.create(dummyBob.id)
-        expired <- authSpec.timeoutAuthenticator(auth)
-        renewed <- authSpec.auth.refresh(expired)
+        auth    <- OptionT.liftF(requestAuth.authenticator.create(dummyBob.id))
+        expired <- OptionT.liftF(authSpec.timeoutAuthenticator(auth))
+        renewed <- OptionT.liftF(authSpec.auth.refresh(expired))
         embedded = authSpec.embedInRequest(Request[IO](uri = Uri.unsafeFromString("/api")), renewed)
         res <- testService(embedded)
       } yield res
@@ -127,7 +127,7 @@ class RequestAuthenticatorSpec extends AuthenticatorSpec {
     it should "Reject an invalid token" in {
 
       val response: OptionT[IO, Response[IO]] = for {
-        auth <- authSpec.wrongKeyAuthenticator
+        auth <- OptionT.liftF(authSpec.wrongKeyAuthenticator)
         embedded = authSpec.embedInRequest(Request[IO](uri = Uri.unsafeFromString("/api")), auth)
         res <- testService(embedded)
       } yield res
@@ -140,8 +140,8 @@ class RequestAuthenticatorSpec extends AuthenticatorSpec {
     //note: we feed it "discarded" because stateless tokens rely on this.
     it should "Fail on a discarded token" in {
       val response: OptionT[IO, Response[IO]] = for {
-        auth      <- requestAuth.authenticator.create(dummyBob.id)
-        discarded <- requestAuth.authenticator.discard(auth)
+        auth      <- OptionT.liftF(requestAuth.authenticator.create(dummyBob.id))
+        discarded <- OptionT.liftF(requestAuth.authenticator.discard(auth))
         embedded = authSpec.embedInRequest(Request[IO](uri = Uri.unsafeFromString("/api")), discarded)
         res <- testService(embedded)
       } yield res
@@ -153,7 +153,7 @@ class RequestAuthenticatorSpec extends AuthenticatorSpec {
 
     it should "authorize for an allowed endpoint" in {
       val response: OptionT[IO, Response[IO]] = for {
-        auth <- requestAuth.authenticator.create(dummyBob.id)
+        auth <- OptionT.liftF(requestAuth.authenticator.create(dummyBob.id))
         embedded = authSpec.embedInRequest(Request[IO](uri = Uri.unsafeFromString("/api")), auth)
         res <- everyoneService(embedded)
       } yield res
@@ -165,7 +165,7 @@ class RequestAuthenticatorSpec extends AuthenticatorSpec {
 
     it should "not authorize for a gated endpoint" in {
       val response: OptionT[IO, Response[IO]] = for {
-        auth <- requestAuth.authenticator.create(dummyBob.id)
+        auth <- OptionT.liftF(requestAuth.authenticator.create(dummyBob.id))
         embedded = authSpec.embedInRequest(Request[IO](uri = Uri.unsafeFromString("/api")), auth)
         res <- adminService(embedded)
       } yield res

--- a/tsec-http4s/src/test/scala/tsec/authentication/SignedCookieAuthenticatorTests.scala
+++ b/tsec-http4s/src/test/scala/tsec/authentication/SignedCookieAuthenticatorTests.scala
@@ -32,19 +32,19 @@ class SignedCookieAuthenticatorTests extends RequestAuthenticatorSpec {
       def embedInRequest(request: Request[IO], authenticator: AuthenticatedCookie[A, Int]): Request[IO] =
         request.addCookie(authenticator.toCookie)
 
-      def expireAuthenticator(b: AuthenticatedCookie[A, Int]): OptionT[IO, AuthenticatedCookie[A, Int]] = {
+      def expireAuthenticator(b: AuthenticatedCookie[A, Int]): IO[AuthenticatedCookie[A, Int]] = {
         val now     = Instant.now()
         val updated = b.copy[A, Int](expiry = now.minusSeconds(2000))
-        OptionT.liftF(store.update(updated)).map(_ => updated)
+        store.update(updated).map(_ => updated)
       }
 
-      def timeoutAuthenticator(b: AuthenticatedCookie[A, Int]): OptionT[IO, AuthenticatedCookie[A, Int]] = {
+      def timeoutAuthenticator(b: AuthenticatedCookie[A, Int]): IO[AuthenticatedCookie[A, Int]] = {
         val now     = Instant.now()
         val updated = b.copy[A, Int](lastTouched = Some(now.minusSeconds(2000)))
-        OptionT.liftF(store.update(updated)).map(_ => updated)
+        store.update(updated).map(_ => updated)
       }
 
-      def wrongKeyAuthenticator: OptionT[IO, AuthenticatedCookie[A, Int]] =
+      def wrongKeyAuthenticator: IO[AuthenticatedCookie[A, Int]] =
         SignedCookieAuthenticator[IO, Int, DummyUser, A](
           TSecCookieSettings(cookieName, false, expiryDuration = 10.minutes, maxIdle = Some(10.minutes)),
           store,


### PR DESCRIPTION
A lot of liftF was making the use of the tsec-http4s api force users to supply getOrElse for ops wherein OptionT wasn't the desired behavior