### PR TITLE
Don't duplicate extraction work in composeExtract

### DIFF
--- a/tsec-http4s/src/main/scala/tsec/authentication/AuthenticatorService.scala
+++ b/tsec-http4s/src/main/scala/tsec/authentication/AuthenticatorService.scala
@@ -104,9 +104,9 @@ object AuthenticatorService {
     )(implicit ev: A <:< Authenticator[I]): AuthExtractorService[F, V, Authenticator[I]] =
       Kleisli { r: Request[F] =>
         auth.extractRawOption(r) match {
-          case Some(_) =>
+          case Some(raw) =>
             auth
-              .extractAndValidate(r)
+              .parseRaw(raw, r)
               .asInstanceOf[OptionT[F, SecuredRequest[F, V, Authenticator[I]]]] //we need to do this :(
           case None =>
             other


### PR DESCRIPTION
Speaking of micro-optimizations!

Calved off of (mostly-)unrelated exploration.