### PR TITLE
Authorization goodies for tsecauthservice + possible bug fix for authenticators

### DIFF
--- a/tsec-http4s/src/main/scala/tsec/authentication/BearerTokenAuthenticator.scala
+++ b/tsec-http4s/src/main/scala/tsec/authentication/BearerTokenAuthenticator.scala
@@ -57,11 +57,12 @@ object BearerTokenAuthenticator {
       def extractRawOption(request: Request[F]): Option[String] = extractBearerToken[F](request)
 
       def parseRaw(raw: String, request: Request[F]): OptionT[F, SecuredRequest[F, V, TSecBearerToken[I]]] =
-        for {
+        (for {
           token     <- tokenStore.get(SecureRandomId.coerce(raw))
           refreshed <- validateAndRefresh(token)
           identity  <- identityStore.get(token.identity)
-        } yield SecuredRequest(request, identity, refreshed)
+        } yield SecuredRequest(request, identity, refreshed))
+          .handleErrorWith(_ => OptionT.none)
 
       def create(body: I): F[TSecBearerToken[I]] =
         for {

--- a/tsec-http4s/src/main/scala/tsec/authentication/JWTAuthenticator.scala
+++ b/tsec-http4s/src/main/scala/tsec/authentication/JWTAuthenticator.scala
@@ -117,13 +117,14 @@ object JWTAuthenticator {
         extractBearerToken[F](request)
 
       def parseRaw(raw: String, request: Request[F]): OptionT[F, SecuredRequest[F, V, AugmentedJWT[A, I]]] =
-        for {
+        (for {
           now       <- OptionT.liftF(F.delay(Instant.now()))
           extracted <- OptionT.liftF(cv.verifyAndParse(raw, signingKey, now))
           retrieved <- tokenStore.get(SecureRandomId.is.flip.coerce(extracted.id))
           refreshed <- verifyAndRefresh(raw, retrieved, now)
           identity  <- identityStore.get(retrieved.identity)
-        } yield SecuredRequest(request, identity, refreshed)
+        } yield SecuredRequest(request, identity, refreshed))
+        .handleErrorWith(_ => OptionT.none)
 
       def create(body: I): F[AugmentedJWT[A, I]] =
         for {
@@ -247,13 +248,14 @@ object JWTAuthenticator {
         request.headers.get(CaseInsensitiveString(settings.headerName)).map(_.value)
 
       def parseRaw(raw: String, request: Request[F]): OptionT[F, SecuredRequest[F, V, AugmentedJWT[A, I]]] =
-        for {
+        (for {
           now       <- OptionT.liftF(F.delay(Instant.now()))
           extracted <- OptionT.liftF(cv.verifyAndParse(raw, signingKey, now))
           retrieved <- tokenStore.get(SecureRandomId.is.flip.coerce(extracted.id))
           refreshed <- verifyAndRefresh(raw, retrieved, now)
           identity  <- identityStore.get(retrieved.identity)
-        } yield SecuredRequest(request, identity, refreshed)
+        } yield SecuredRequest(request, identity, refreshed))
+          .handleErrorWith(_ => OptionT.none)
 
       def create(body: I): F[AugmentedJWT[A, I]] =
         for {
@@ -376,7 +378,7 @@ object JWTAuthenticator {
         extractBearerToken(request)
 
       def parseRaw(raw: String, request: Request[F]): OptionT[F, SecuredRequest[F, V, AugmentedJWT[A, I]]] =
-        for {
+        (for {
           now         <- OptionT.liftF(F.delay(Instant.now()))
           extracted   <- OptionT.liftF(cv.verifyAndParse(raw, signingKey, now))
           id          <- OptionT.fromOption[F](extracted.body.subject.flatMap(decode[I](_).toOption))
@@ -391,7 +393,8 @@ object JWTAuthenticator {
           )
           refreshed <- OptionT.liftF(refresh(augmented))
           identity  <- identityStore.get(id)
-        } yield SecuredRequest(request, identity, refreshed)
+        } yield SecuredRequest(request, identity, refreshed))
+          .handleErrorWith(_ => OptionT.none)
 
       def create(body: I): F[AugmentedJWT[A, I]] =
         for {
@@ -556,7 +559,7 @@ object JWTAuthenticator {
         extractBearerToken[F](request)
 
       def parseRaw(raw: String, request: Request[F]): OptionT[F, SecuredRequest[F, V, AugmentedJWT[A, I]]] =
-        for {
+        (for {
           eInstance   <- OptionT.liftF(F.fromEither(enc.instance)) // Todo: pls my heart
           now         <- OptionT.liftF(F.delay(Instant.now))
           extracted   <- OptionT.liftF(cv.verifyAndParse(raw, signingKey, now))
@@ -573,7 +576,8 @@ object JWTAuthenticator {
           )
           refreshed <- OptionT.liftF(refresh(augmented))
           identity  <- identityStore.get(decodedBody)
-        } yield SecuredRequest(request, identity, refreshed)
+        } yield SecuredRequest(request, identity, refreshed))
+          .handleErrorWith(_ => OptionT.none)
 
       def create(body: I): F[AugmentedJWT[A, I]] =
         for {
@@ -720,7 +724,7 @@ object JWTAuthenticator {
         request.headers.get(CaseInsensitiveString(settings.headerName)).map(_.value)
 
       def parseRaw(raw: String, request: Request[F]): OptionT[F, SecuredRequest[F, V, AugmentedJWT[A, I]]] =
-        for {
+        (for {
           eInstance   <- OptionT.liftF(F.fromEither(enc.instance))
           now         <- OptionT.liftF(F.delay(Instant.now))
           extracted   <- OptionT.liftF(cv.verifyAndParse(raw, signingKey, now))
@@ -737,7 +741,8 @@ object JWTAuthenticator {
           )
           refreshed <- OptionT.liftF(refresh(augmented))
           identity  <- identityStore.get(decodedBody)
-        } yield SecuredRequest(request, identity, refreshed)
+        } yield SecuredRequest(request, identity, refreshed))
+          .handleErrorWith(_ => OptionT.none)
 
       def create(body: I): F[AugmentedJWT[A, I]] =
         for {

--- a/tsec-http4s/src/main/scala/tsec/authentication/SecuredRequestHandler.scala
+++ b/tsec-http4s/src/main/scala/tsec/authentication/SecuredRequestHandler.scala
@@ -37,7 +37,7 @@ sealed abstract class SecuredRequestHandler[F[_], Identity, User, Auth](
     val middleware = TSecMiddleware(Kleisli(authenticator.extractAndValidate), onNotAuthenticated)
 
     middleware(service)
-      .handleErrorWith(e => Kleisli.lift(OptionT.pure(cachedUnauthorized)))
+      .handleErrorWith(_ => Kleisli.lift(OptionT.pure(cachedUnauthorized)))
   }
 
   /** Create an Authorized Service **/
@@ -53,7 +53,7 @@ sealed abstract class SecuredRequestHandler[F[_], Identity, User, Auth](
       onNotAuthenticated: Request[F] => F[Response[F]] = defaultNotAuthenticated
   ): HttpService[F] =
     authorizedMiddleware(authorization, onNotAuthenticated)(service)
-      .handleErrorWith(e => Kleisli.lift(OptionT.pure(cachedUnauthorized)))
+      .handleErrorWith(_ => Kleisli.lift(OptionT.pure(cachedUnauthorized)))
 
 }
 
@@ -82,7 +82,7 @@ object SecuredRequestHandler {
       ): HttpService[F] = {
         val middleware = TSecMiddleware(Kleisli(authenticator.extractAndValidate), onNotAuthenticated)
         middleware(TSecAuthService(pf, authenticator.afterBlock))
-          .handleErrorWith(e => Kleisli.lift(OptionT.pure(cachedUnauthorized)))
+          .handleErrorWith(_ => Kleisli.lift(OptionT.pure(cachedUnauthorized)))
       }
 
       /** Create an Authorized Service **/
@@ -91,7 +91,7 @@ object SecuredRequestHandler {
           onNotAuthenticated: Request[F] => F[Response[F]] = defaultNotAuthenticated
       ): HttpService[F] =
         authorizedMiddleware(authorization, onNotAuthenticated)(TSecAuthService(pf, authenticator.afterBlock))
-          .handleErrorWith(e => Kleisli.lift(OptionT.pure(cachedUnauthorized)))
+          .handleErrorWith(_ => Kleisli.lift(OptionT.pure(cachedUnauthorized)))
 
     }
 
@@ -109,7 +109,7 @@ object SecuredRequestHandler {
         val middleware = TSecMiddleware(Kleisli(authenticator.extractAndValidate), onNotAuthenticated)
 
         middleware(TSecAuthService(pf))
-          .handleErrorWith(e => Kleisli.lift(OptionT.pure(cachedUnauthorized)))
+          .handleErrorWith(_ => Kleisli.lift(OptionT.pure(cachedUnauthorized)))
 
       }
 
@@ -119,7 +119,7 @@ object SecuredRequestHandler {
           onNotAuthenticated: Request[F] => F[Response[F]] = defaultNotAuthenticated
       ): HttpService[F] =
         authorizedMiddleware(authorization, onNotAuthenticated)(TSecAuthService(pf))
-          .handleErrorWith(e => Kleisli.lift(OptionT.pure(cachedUnauthorized)))
+          .handleErrorWith(_ => Kleisli.lift(OptionT.pure(cachedUnauthorized)))
 
     }
 


### PR DESCRIPTION
Closes #81 

- `onNotAuthorized` was wrong (my bad), I actually meant `onNotAuthenticated`
- There was no error handling within `parseRaw` for Authenticators. Given something may fail with `F.raiseError`, this shouldn't necessarily fall in the catch all handler. This should simply go immediately to the `onNotAuthenticated` handler (by being `OptionT.none)