### PR TITLE
Upgrading to Cats 1.0.1

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -20,7 +20,7 @@ lazy val scalacOpts = scalacOptions := Seq(
 )
 
 lazy val micrositeSettings = Seq(
-  libraryDependencies += "com.47deg" %% "github4s" % "0.17.0",
+  libraryDependencies += Libraries.gitHub4s,
   micrositeName := "TSec",
   micrositeBaseUrl := "/tsec",
   micrositeDescription := "A Type-Safe General Cryptography Library on the JVM",

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -4,18 +4,19 @@ import Keys._
 object Dependencies {
 
   object Versions {
-    val circeV        = "0.9.0-M3"
-    val catsV         = "1.0.0-RC2"
-    val catsEffV      = "0.6"
+    val circeV        = "0.9.0"
+    val catsV         = "1.0.1"
+    val catsEffV      = "0.7"
     val thymeV        = "0.1.2-SNAPSHOT"
     val bouncyCastleV = "1.58"
     val sCryptV       = "1.4.0"
     val scalaTestV    = "3.0.4"
-    val http4sV       = "0.18.0-M7"
+    val http4sV       = "0.18.0-M8"
     val scalacheckV   = "1.13.5"
     val commonsCodecV = "1.11"
-    val fs2Version    = "0.10.0-M10"
+    val fs2Version    = "0.10.0-M11"
     val log4sV        = "1.4.0"
+    val gitHub4s      = "0.17.0"
   }
 
   object Libraries {
@@ -37,6 +38,7 @@ object Dependencies {
     val scalaCheck         = "org.scalacheck"     %% "scalacheck"           % Versions.scalacheckV % "test"
     val commonsCodec       = "commons-codec"      % "commons-codec"         % Versions.commonsCodecV
     val log4s              = "org.log4s"          %% "log4s"                % Versions.log4sV
+    val gitHub4s           = "com.47deg"          %% "github4s"             % Versions.gitHub4s
   }
 
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -6,7 +6,7 @@ object Dependencies {
   object Versions {
     val circeV        = "0.9.0"
     val catsV         = "1.0.1"
-    val catsEffV      = "0.7"
+    val catsEffV      = "0.8"
     val thymeV        = "0.1.2-SNAPSHOT"
     val bouncyCastleV = "1.58"
     val sCryptV       = "1.4.0"

--- a/tsec-libsodium/src/test/scala/tsec/libsodium/GenericHash.scala
+++ b/tsec-libsodium/src/test/scala/tsec/libsodium/GenericHash.scala
@@ -27,7 +27,7 @@ class GenericHash extends SodiumSpec {
       forAll { (s: String) =>
         val program = for {
           h1 <- platform.hash[IO](s.utf8Bytes)
-          h2 <- Stream.emits(s.utf8Bytes).covary[IO].through(platform.hashPipe).runLog
+          h2 <- Stream.emits(s.utf8Bytes).covary[IO].through(platform.hashPipe).compile.toVector
         } yield (h1, h2.toArray)
 
         val (h1, h2) = program.unsafeRunSync()

--- a/tsec-libsodium/src/test/scala/tsec/libsodium/SodiumStreamCipherTest.scala
+++ b/tsec-libsodium/src/test/scala/tsec/libsodium/SodiumStreamCipherTest.scala
@@ -32,7 +32,8 @@ class SodiumStreamCipherTest extends SodiumSpec {
         .covary[IO]
         .through(XChacha20Poly1305.encryptionPipe[IO](state, 10))
         .through(XChacha20Poly1305.decryptionPipe[IO](state.header, key, 10))
-        .runLog
+        .compile
+        .toVector
     } yield original.toArray
 
     program.unsafeRunSync().toHexString mustBe testVector.toHexString
@@ -48,7 +49,8 @@ class SodiumStreamCipherTest extends SodiumSpec {
         .covary[IO]
         .through(XChacha20Poly1305.encryptionPipe[IO](state, 10))
         .through(XChacha20Poly1305.decryptionPipe[IO](state.header, key2, 10))
-        .runLog
+        .compile
+        .toVector
     } yield original.toArray
 
     program.attempt.unsafeRunSync() mustBe a[Left[SodiumCipherError, _]]
@@ -65,7 +67,8 @@ class SodiumStreamCipherTest extends SodiumSpec {
         .covary[IO]
         .through(XChacha20Poly1305.encryptionPipe[IO](state1, 10))
         .through(XChacha20Poly1305.decryptionPipe[IO](state2.header, key2, 10))
-        .runLog
+        .compile
+        .toVector
     } yield original.toArray
 
     program.attempt.unsafeRunSync() mustBe a[Left[SodiumCipherError, _]]


### PR DESCRIPTION
Simple upgrade to latest Cats. Just as a note, GitHub4s is still on Cats 1.0.0-RC2 and it won't upgrade until this issue is fixed: https://github.com/circe/circe/issues/819