### PR TITLE
Expire signed cookie on discard

### DIFF
--- a/tsec-http4s/src/main/scala/tsec/authentication/EncryptedCookieAuthenticator.scala
+++ b/tsec-http4s/src/main/scala/tsec/authentication/EncryptedCookieAuthenticator.scala
@@ -430,8 +430,7 @@ object EncryptedCookieAuthenticator {
         * @return
         */
       def discard(authenticator: AuthEncryptedCookie[A, I]): F[AuthEncryptedCookie[A, I]] =
-        F.delay(Instant.now())
-          .map(now => authenticator.copy[A, I](content = AEADCookie[A]("invalid"), expiry = now))
+        F.delay(authenticator.copy[A, I](content = AEADCookie[A]("invalid"), expiry = Instant.EPOCH))
 
       /** Renew all of our cookie's possible expirations.
         * If there is a timeout, refresh that as well. otherwise, simply update the expiry.

--- a/tsec-http4s/src/main/scala/tsec/authentication/EncryptedCookieAuthenticator.scala
+++ b/tsec-http4s/src/main/scala/tsec/authentication/EncryptedCookieAuthenticator.scala
@@ -265,7 +265,7 @@ object EncryptedCookieAuthenticator {
         *
         */
       def discard(authenticator: AuthEncryptedCookie[A, I]): F[AuthEncryptedCookie[A, I]] =
-        tokenStore.delete(authenticator.id).map(_ => authenticator)
+        tokenStore.delete(authenticator.id).map(_ => authenticator.copy(expiry = Instant.EPOCH))
 
       /** Renew, aka reset both the expiry as well as the last touched (if present) value
         *

--- a/tsec-http4s/src/main/scala/tsec/authentication/SignedCookieAuthenticator.scala
+++ b/tsec-http4s/src/main/scala/tsec/authentication/SignedCookieAuthenticator.scala
@@ -189,7 +189,9 @@ object SignedCookieAuthenticator {
         tokenStore.update(authenticator)
 
       def discard(authenticator: AuthenticatedCookie[Alg, I]): F[AuthenticatedCookie[Alg, I]] =
-        tokenStore.delete(authenticator.id).map(_ => authenticator)
+        tokenStore
+          .delete(authenticator.id)
+          .map(_ => authenticator.copy(content = SignedCookie[Alg]("invalid"), expiry = Instant.EPOCH))
 
       /** Renew an authenticator: Reset it's expiry and whatnot.
         *

--- a/tsec-http4s/src/test/scala/tsec/authentication/SignedCookieAuthenticatorTests.scala
+++ b/tsec-http4s/src/test/scala/tsec/authentication/SignedCookieAuthenticatorTests.scala
@@ -69,4 +69,27 @@ class SignedCookieAuthenticatorTests extends RequestAuthenticatorSpec {
   CookieReqTest[HMACSHA384]("HMACSHA384 Authenticator", genAuthenticator[HMACSHA384])
   CookieReqTest[HMACSHA512]("HMACSHA512 Authenticator", genAuthenticator[HMACSHA512])
 
+  def signedCookieTests[A: MacTag](auth: AuthSpecTester[AuthenticatedCookie[A, Int]]) = {
+
+    behavior of "Signed Cookie Authenticator " + MacTag[A].algorithm
+
+    it should "expire tokens on discard" in {
+
+      val program: IO[Boolean] = for {
+        cookie  <- auth.auth.create(0)
+        expired <- auth.auth.discard(cookie)
+        now     <- IO(Instant.now())
+      } yield SignedCookieAuthenticator.isExpired(expired, now, None)
+
+      program.unsafeRunSync() mustBe false
+
+    }
+
+  }
+
+  signedCookieTests[HMACSHA1](genAuthenticator[HMACSHA1])
+  signedCookieTests[HMACSHA256](genAuthenticator[HMACSHA256])
+  signedCookieTests[HMACSHA384](genAuthenticator[HMACSHA384])
+  signedCookieTests[HMACSHA512](genAuthenticator[HMACSHA512])
+
 }


### PR DESCRIPTION
And streamline the expiry for encrypted cookies (by using `Instant.EPOCH`)

I looked at adding a test for it, but I couldn't figure out how to only
target the cookie-based authenticators.