### PR TITLE
Remove throwable as the only supertype of TSecError

### DIFF
--- a/common/src/main/scala/tsec/common/package.scala
+++ b/common/src/main/scala/tsec/common/package.scala
@@ -12,7 +12,11 @@ import scala.util.control.NoStackTrace
 
 package object common {
 
-  trait TSecError extends NoStackTrace {
+  trait TSecError extends Exception {
+    override def fillInStackTrace(): Throwable =
+      if (NoStackTrace.noSuppression) super.fillInStackTrace()
+      else this
+
     def cause: String
     override def getMessage: String = cause
   }

--- a/common/src/main/scala/tsec/common/package.scala
+++ b/common/src/main/scala/tsec/common/package.scala
@@ -12,11 +12,7 @@ import scala.util.control.NoStackTrace
 
 package object common {
 
-  trait TSecError extends Exception {
-    override def fillInStackTrace(): Throwable =
-      if (NoStackTrace.noSuppression) super.fillInStackTrace()
-      else this
-
+  trait TSecError extends Exception with NoStackTrace {
     def cause: String
     override def getMessage: String = cause
   }


### PR DESCRIPTION
I had no idea `NoStackTrace` didn't extend `Exception` instead of `Throwable` :|