### PR TITLE
Add Settings to Automatically Publish Docs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ before_install:
 - sudo ldconfig
 - cd ..
 - sudo -E apt-get -yq --no-install-suggests --no-install-recommends install swig
+- export PATH=${PATH}:./vendor/bundle
 
 scala:
   - 2.12.4
@@ -30,11 +31,20 @@ jdk:
   - oraclejdk8
   - openjdk8
 
+install:
+- rvm use 2.2.8 --install --fuzzy
+- gem update --system
+- gem install sass
+- gem install jekyll -v 3.2.1
+
 script:
   - bash sodium_setup.sh
   - sbt ++$TRAVIS_SCALA_VERSION clean
   - sbt ++$TRAVIS_SCALA_VERSION test
   - test $TRAVIS_SCALA_VERSION == "2.12.4" && sbt ++$TRAVIS_SCALA_VERSION tut || test $TRAVIS_SCALA_VERSION == "2.11.11"
+  - test $TRAVIS_SCALA_VERSION == "2.12.4" && sbt ++$TRAVIS_SCALA_VERSION microsite/makeMicrosite || test $TRAVIS_SCALA_VERSION == "2.11.11"
+
 
 after_success:
 - test $TRAVIS_PULL_REQUEST == "false" && test $TRAVIS_BRANCH == "master" && test $TRAVIS_REPO_SLUG == "jmcardon/tsec" && test $TRAVIS_JDK_VERSION == "oraclejdk8" && sbt ++$TRAVIS_SCALA_VERSION publish
+- test $TRAVIS_PULL_REQUEST == "false" && test $TRAVIS_BRANCH == "master" && test $TRAVIS_REPO_SLUG == "jmcardon/tsec" && test $TRAVIS_JDK_VERSION == "oraclejdk8" && test $TRAVIS_SCALA_VERSION == "2.12.4" sbt ++$TRAVIS_SCALA_VERSION microsite/publishMicrosite

--- a/build.sbt
+++ b/build.sbt
@@ -159,8 +159,9 @@ lazy val root = project
     jwtMac,
     jwtSig,
     passwordHashers,
-    http4s
-  )
+    http4s,
+    microsite
+  ).settings(noPublishSettings)
 
 lazy val common = Project(id = "tsec-common", base = file("common"))
   .settings(commonSettings)
@@ -267,7 +268,7 @@ lazy val bench = Project(id = "tsec-bench", base = file("bench"))
   .dependsOn(bouncyCipher)
   .dependsOn(bouncyHash)
   .dependsOn(mac)
-  .settings(publish := {})
+  .settings(noPublishSettings)
   .enablePlugins(JmhPlugin)
 
 lazy val examples = Project(id = "tsec-examples", base = file("examples"))
@@ -290,7 +291,7 @@ lazy val examples = Project(id = "tsec-examples", base = file("examples"))
     bouncyCipher,
     libsodium
   )
-  .settings(publish := {})
+  .settings(noPublishSettings)
 
 lazy val http4s = Project(id = "tsec-http4s", base = file("tsec-http4s"))
   .settings(commonSettings)
@@ -321,7 +322,7 @@ lazy val libsodium = Project(id = "tsec-libsodium", base = file("tsec-libsodium"
   .settings(releaseSettings)
 
 lazy val microsite = Project(id = "microsite", base = file("docs"))
-  .settings(commonSettings)
+  .settings(commonSettings, noPublishSettings)
   .settings(micrositeSettings)
   .enablePlugins(MicrositesPlugin)
   .enablePlugins(TutPlugin)
@@ -347,3 +348,13 @@ lazy val publishSettings = Seq(
   autoAPIMappings := true,
   apiURL := None
 )
+
+lazy val noPublishSettings = {
+  import com.typesafe.sbt.pgp.PgpKeys.publishSigned
+  Seq(
+    publish := {},
+    publishLocal := {},
+    publishSigned := {},
+    publishArtifact := false
+  )
+}


### PR DESCRIPTION
Automatically publish docs from travis.

Adds `noPublishSettings`, installs ruby stuff for jekyll, adds test for correct publication and then a publish if after_sucess.