### PR TITLE
(WIP) Key rotation for tsec-http4s

### DIFF
--- a/tsec-http4s/src/main/scala/tsec/keyrotation/KeyStrategy.scala
+++ b/tsec-http4s/src/main/scala/tsec/keyrotation/KeyStrategy.scala
@@ -1,0 +1,44 @@
+package tsec.keyrotation
+
+import java.security.KeyStore
+
+import cats.Applicative
+import cats.effect.Sync
+import cats.syntax.flatMap._
+import fs2.async.Ref
+
+abstract class KeyStrategy[F[_], K[_], A] {
+  def retrieveKey: F[K[A]]
+}
+
+object StaticKeyStrategy {
+  def apply[F[_]]: StaticKSBuilder[F] = new StaticKSBuilder[F]()
+
+  private[tsec] final class StaticKSBuilder[F[_]](val dummy: Boolean = false) extends AnyVal {
+    def apply[K[_], A](key: K[A])(implicit F: Applicative[F]): KeyStrategy[F, K, A] = new KeyStrategy[F, K, A] {
+      override val retrieveKey: F[K[A]] = F.pure(key)
+    }
+  }
+}
+
+object JavaKeystoreStrategy {
+  def fromKey[F[_]]: JavaKSBuilder[F] = new JavaKSBuilder[F]()
+
+  private[tsec] final class JavaKSBuilder[F[_]](val dummy: Boolean = false) extends AnyVal {
+    def apply[K[_], A](keystore: KeyStore, alias: String, password: Array[Char], build: Array[Byte] => F[K[A]])(
+        implicit F: Sync[F]
+    ): KeyStrategy[F, K, A] = new KeyStrategy[F, K, A] {
+      def retrieveKey: F[K[A]] = F.delay(keystore.getKey(alias, password)).flatMap(b => build(b.getEncoded))
+    }
+  }
+}
+
+object RefStrategy {
+  def apply[F[_]]: RefBuilder[F] = new RefBuilder[F]
+
+  private[tsec] final class RefBuilder[F[_]](val dummy: Boolean = false) extends AnyVal {
+    def apply[K[_], A](r: Ref[F, K[A]]): KeyStrategy[F, K, A] = new KeyStrategy[F, K, A] {
+      def retrieveKey: F[K[A]] = r.get
+    }
+  }
+}

--- a/tsec-http4s/src/main/scala/tsec/keyrotation/rotato.scala
+++ b/tsec-http4s/src/main/scala/tsec/keyrotation/rotato.scala
@@ -1,0 +1,142 @@
+package tsec.keyrotation
+
+import cats.effect._
+import cats.syntax.functor._
+import cats.syntax.flatMap._
+import fs2.Stream
+import fs2.async.Ref
+import fs2.async.mutable.Signal
+import tsec.cipher.symmetric.jca.SecretKey
+import tsec.keygen.symmetric.SymmetricKeyGen
+import tsec.mac.jca.MacSigningKey
+
+import scala.concurrent.ExecutionContext
+import scala.concurrent.duration.FiniteDuration
+
+abstract class TimedRotator[F[_], K[_], A](
+    private[this] val timeout: FiniteDuration,
+    private[this] val internal: Ref[F, K[A]],
+    private[this] val T: Timer[F],
+    private[this] val terminationSignal: Signal[F, Boolean]
+)(implicit F: ConcurrentEffect[F], ec: ExecutionContext) {
+
+  /** Return a KeyStrategy, which you can use for
+    * instantiating an `Authenticator`
+    *
+    * @return key strategy
+    */
+  final def getStrategy: KeyStrategy[F, K, A] = RefStrategy[F](internal)
+
+  /** Generate or fetch a new key.
+    * In particular, this is a flexible signature in that you can
+    * make `F[_]` be a network call.
+    *
+    */
+  def generateNew: F[K[A]]
+
+  /** Replace our key in our internal atomic reference */
+  def rotateKey(): F[Unit] =
+    for {
+      newKey <- generateNew
+      _      <- internal.setSync(newKey)
+    } yield ()
+
+  /** Return a stream of events wherein every emitted action is the evaluation
+    * of a rotation
+    */
+  def rotatoStream: Stream[F, Unit] =
+    Stream
+      .repeatEval[F, Unit](T.sleep(timeout) >> rotateKey)
+      .interruptWhen(terminationSignal)
+
+  /** Consume the key rot stream concurrently and
+    * fork it
+    */
+  def rotato: F[Unit] =
+    F.start(T.shift >> rotatoStream.compile.drain).as(())
+
+}
+
+object InMemoryTimedRotator {
+
+  def macKeyRotato[F[_]: ConcurrentEffect, A](
+      timeout: FiniteDuration,
+      T: Timer[F]
+  )(
+      implicit K: SymmetricKeyGen[F, A, MacSigningKey],
+      ec: ExecutionContext
+  ): Stream[F, TimedRotator[F, MacSigningKey, A]] =
+    Stream
+      .eval(for {
+        key            <- K.generateKey
+        newRef         <- Ref[F, MacSigningKey[A]](key)
+        shutdownSignal <- Signal[F, Boolean](false)
+      } yield (newRef, shutdownSignal))
+      .flatMap {
+        case (ref, signal) =>
+          Stream
+            .emit(new TimedRotator[F, MacSigningKey, A](timeout, ref, T, signal) {
+              def generateNew: F[MacSigningKey[A]] = K.generateKey
+            })
+            .onFinalize(signal.set(true))
+      }
+
+  def macKeyRotatoEffect[F[_]: ConcurrentEffect, A](
+      timeout: FiniteDuration,
+      T: Timer[F]
+  )(
+      implicit K: SymmetricKeyGen[F, A, MacSigningKey],
+      ec: ExecutionContext
+  ): F[(TimedRotator[F, MacSigningKey, A], F[Unit])] =
+    (for {
+      key            <- K.generateKey
+      newRef         <- Ref[F, MacSigningKey[A]](key)
+      shutdownSignal <- Signal[F, Boolean](false)
+    } yield (newRef, shutdownSignal)).map {
+      case (ref, signal) =>
+        (new TimedRotator[F, MacSigningKey, A](timeout, ref, T, signal) {
+          def generateNew: F[MacSigningKey[A]] = K.generateKey
+        }, signal.set(true))
+    }
+
+  def cipherKeyRotato[F[_]: ConcurrentEffect, A](
+      timeout: FiniteDuration,
+      T: Timer[F]
+  )(
+      implicit K: SymmetricKeyGen[F, A, SecretKey],
+      ec: ExecutionContext
+  ): Stream[F, TimedRotator[F, SecretKey, A]] =
+    Stream
+      .eval(for {
+        key            <- K.generateKey
+        newRef         <- Ref[F, SecretKey[A]](key)
+        shutdownSignal <- Signal[F, Boolean](false)
+      } yield (newRef, shutdownSignal))
+      .flatMap {
+        case (ref, signal) =>
+          Stream
+            .emit(new TimedRotator[F, SecretKey, A](timeout, ref, T, signal) {
+              def generateNew: F[SecretKey[A]] = K.generateKey
+            })
+            .onFinalize(signal.set(true))
+      }
+
+  def cipherKeyRotatoEffect[F[_]: ConcurrentEffect, A](
+      timeout: FiniteDuration,
+      T: Timer[F]
+  )(
+      implicit K: SymmetricKeyGen[F, A, SecretKey],
+      ec: ExecutionContext
+  ): F[(TimedRotator[F, SecretKey, A], F[Unit])] =
+    (for {
+      key            <- K.generateKey
+      newRef         <- Ref[F, SecretKey[A]](key)
+      shutdownSignal <- Signal[F, Boolean](false)
+    } yield (newRef, shutdownSignal)).map {
+      case (ref, signal) =>
+        (new TimedRotator[F, SecretKey, A](timeout, ref, T, signal) {
+          def generateNew: F[SecretKey[A]] = K.generateKey
+        }, signal.set(true))
+    }
+
+}


### PR DESCRIPTION
This is a fairly simple but powerful implementation of key rotation based off of our primitives.

This is source compatible,but adds and changes quite a few sigs.

In particular, I would love if you guys could take a look at `TimedRotator`. I'm not sure if something is off there: I am relying on `Timer[F]` and `ExecutionContext` as well as `ConcurrentEffect`. I'm very unsure whether those should abstract and defined @ the impl site, without burdening the class with the heavy constraining. Opinions highly sought