### PR TITLE
Remove more useless tag classes

### DIFF
--- a/bench/src/main/scala/tsec/CipherBench.scala
+++ b/bench/src/main/scala/tsec/CipherBench.scala
@@ -24,7 +24,7 @@ class CipherBench {
 
   /** AES using tsec classes **/
   implicit lazy val jcaAESInstance: AADEncryptor[IO, JAESGCM, SecretKey] =
-    JAESGCM.genEncryptor[IO].unsafeRunSync()
+    JAESGCM.genEncryptor[IO]
 
   /** Our AES using the JCA raw classes. Note: We reuse cipher the instance for speed, but it's not thread safe **/
   lazy val jcaRAWKey: crypto.SecretKey = SecretKey.toJavaKey(JAESGCM.unsafeGenerateKey)

--- a/cipher-symmetric/src/main/scala/tsec/cipher/symmetric/jca/AESCBC.scala
+++ b/cipher-symmetric/src/main/scala/tsec/cipher/symmetric/jca/AESCBC.scala
@@ -8,8 +8,8 @@ import tsec.cipher.symmetric.jca.primitive._
 sealed abstract class AESCBC[A] extends JCACipherAPI[A, CBC, PKCS7Padding] with AES[A] with JCAKeyGen[A] {
   implicit val ac: AESCBC[A] = this
 
-  def encryptor[F[_]: Sync](implicit c: BlockCipher[A]): F[Encryptor[F, A, SecretKey]] =
-    JCAPrimitiveCipher.sync[F, A, CBC, PKCS7Padding]()
+  implicit def genEncryptor[F[_]: Sync](implicit c: BlockCipher[A]): JCAPrimitiveCipher[F, A, CBC, PKCS7Padding] =
+    JCAPrimitiveCipher.sync[F, A, CBC, PKCS7Padding]
 
   def defaultIvStrategy[F[_]: Sync](implicit c: BlockCipher[A]): IvGen[F, A] = JCAIvGen.random[F, A]
 

--- a/cipher-symmetric/src/main/scala/tsec/cipher/symmetric/jca/AESCTR.scala
+++ b/cipher-symmetric/src/main/scala/tsec/cipher/symmetric/jca/AESCTR.scala
@@ -10,8 +10,8 @@ import tsec.cipher.symmetric.jca.primitive.JCAPrimitiveCipher
 sealed abstract class AESCTR[A] extends JCACipherAPI[A, CTR, NoPadding] with AES[A] with JCAKeyGen[A] {
   implicit val ae: AESCTR[A] = this
 
-  def genEncryptor[F[_]: Sync](implicit c: BlockCipher[A]): F[Encryptor[F, A, SecretKey]] =
-    JCAPrimitiveCipher.sync[F, A, CTR, NoPadding]()
+  implicit def genEncryptor[F[_]: Sync](implicit c: BlockCipher[A]): JCAPrimitiveCipher[F, A, CTR, NoPadding] =
+    JCAPrimitiveCipher.sync[F, A, CTR, NoPadding]
 
   /** Our default Iv strategy for CTR mode
     * produces randomized IVs

--- a/cipher-symmetric/src/main/scala/tsec/cipher/symmetric/jca/AESGCM.scala
+++ b/cipher-symmetric/src/main/scala/tsec/cipher/symmetric/jca/AESGCM.scala
@@ -10,8 +10,8 @@ import tsec.cipher.symmetric.jca.primitive.JCAAEADPrimitive
 sealed abstract class AESGCM[A] extends JCAAEAD[A, GCM, NoPadding] with AES[A] with JCAKeyGen[A] {
   implicit val ae: AESGCM[A] = this
 
-  def genEncryptor[F[_]: Sync](implicit c: AES[A]): F[AADEncryptor[F, A, SecretKey]] =
-    JCAAEADPrimitive.sync[F, A, GCM, NoPadding]()
+  implicit def genEncryptor[F[_]: Sync](implicit c: AES[A]): AADEncryptor[F, A, SecretKey] =
+    JCAAEADPrimitive.sync[F, A, GCM, NoPadding]
 
   /** Our default Iv strategy for GCM mode
     * produces randomized IVs

--- a/cipher-symmetric/src/main/scala/tsec/cipher/symmetric/jca/primitive/JCAAEADPrimitive.scala
+++ b/cipher-symmetric/src/main/scala/tsec/cipher/symmetric/jca/primitive/JCAAEADPrimitive.scala
@@ -1,6 +1,5 @@
 package tsec.cipher.symmetric.jca.primitive
 
-import java.util.concurrent.{ConcurrentLinkedQueue => JQueue}
 import java.util.{Arrays => JaRule}
 import javax.crypto.{Cipher => JCipher}
 
@@ -10,32 +9,26 @@ import cats.syntax.all._
 import tsec.cipher.common.padding.SymmetricPadding
 import tsec.cipher.symmetric._
 import tsec.cipher.symmetric.jca._
-import tsec.common.CanCatch
 
-sealed abstract class JCAAEADPrimitive[F[_], A, M, P](private val queue: JQueue[JCipher])(
+sealed abstract class JCAAEADPrimitive[F[_], A, M, P](
     implicit algoTag: BlockCipher[A],
     aead: AEADCipher[A],
     modeSpec: CipherMode[M],
     paddingTag: SymmetricPadding[P],
     F: MonadError[F, Throwable],
     private[tsec] val ivProcess: IvProcess[A, M, P]
-) extends AADEncryptor[F, A, SecretKey]
-    with CanCatch[F] {
+) extends AADEncryptor[F, A, SecretKey] {
 
-  private def getInstance: JCipher = {
-    val instance = queue.poll()
-    if (instance != null)
-      instance
-    else
-      JCAPrimitiveCipher.getJCipherUnsafe[A, M, P]
-  }
+  private def getInstance: JCipher =
+    JCAPrimitiveCipher.getJCipherUnsafe[A, M, P]
+
+  private[tsec] def catchF[Y](a: => Y): F[Y]
 
   def encrypt(plainText: PlainText, key: SecretKey[A], iv: Iv[A]): F[CipherText[A]] =
     catchF {
       val instance = getInstance
       ivProcess.encryptInit(instance, iv, key.toJavaKey)
       val encrypted = instance.doFinal(plainText)
-      queue.add(instance)
       CipherText[A](RawCipherText(encrypted), iv)
     }
 
@@ -44,7 +37,6 @@ sealed abstract class JCAAEADPrimitive[F[_], A, M, P](private val queue: JQueue[
       val instance = getInstance
       ivProcess.decryptInit(instance, cipherText.nonce, key.toJavaKey)
       val out = instance.doFinal(cipherText.content)
-      queue.add(instance)
       PlainText(out)
     }
 
@@ -54,7 +46,6 @@ sealed abstract class JCAAEADPrimitive[F[_], A, M, P](private val queue: JQueue[
       ivProcess.encryptInit(instance, iv, key.toJavaKey)
       instance.updateAAD(aad)
       val encrypted = RawCipherText[A](instance.doFinal(plainText))
-      queue.add(instance)
       CipherText[A](encrypted, iv)
     }
 
@@ -64,7 +55,6 @@ sealed abstract class JCAAEADPrimitive[F[_], A, M, P](private val queue: JQueue[
       ivProcess.decryptInit(instance, cipherText.nonce, key.toJavaKey)
       instance.updateAAD(aad)
       val out = instance.doFinal(cipherText.content)
-      queue.add(instance)
       PlainText(out)
     }
 
@@ -72,8 +62,7 @@ sealed abstract class JCAAEADPrimitive[F[_], A, M, P](private val queue: JQueue[
     catchF {
       val instance = getInstance
       ivProcess.encryptInit(instance, iv, key.toJavaKey)
-      val encrypted = instance.doFinal(plainText)
-      queue.add(instance)
+      val encrypted  = instance.doFinal(plainText)
       val cipherText = RawCipherText[A](JaRule.copyOfRange(encrypted, 0, encrypted.length - aead.tagSizeBytes))
       val tag        = JaRule.copyOfRange(encrypted, encrypted.length - aead.tagSizeBytes, encrypted.length)
       (CipherText[A](cipherText, iv), AuthTag[A](tag))
@@ -92,7 +81,6 @@ sealed abstract class JCAAEADPrimitive[F[_], A, M, P](private val queue: JQueue[
         System.arraycopy(tag, 0, combined, cipherText.content.length, tag.length)
 
         val out = instance.doFinal(combined)
-        queue.add(instance)
         PlainText(out)
       }
 
@@ -106,8 +94,7 @@ sealed abstract class JCAAEADPrimitive[F[_], A, M, P](private val queue: JQueue[
       val instance = getInstance
       ivProcess.encryptInit(instance, iv, key.toJavaKey)
       instance.updateAAD(aad)
-      val encrypted = instance.doFinal(plainText)
-      queue.add(instance)
+      val encrypted  = instance.doFinal(plainText)
       val cipherText = RawCipherText[A](JaRule.copyOfRange(encrypted, 0, encrypted.length - aead.tagSizeBytes))
       val tag        = JaRule.copyOfRange(encrypted, encrypted.length - aead.tagSizeBytes, encrypted.length)
       (CipherText[A](cipherText, iv), AuthTag[A](tag))
@@ -128,7 +115,6 @@ sealed abstract class JCAAEADPrimitive[F[_], A, M, P](private val queue: JQueue[
 
         instance.updateAAD(aad)
         val out = instance.doFinal(combined)
-        queue.add(instance)
         PlainText(out)
       }
 
@@ -137,22 +123,19 @@ sealed abstract class JCAAEADPrimitive[F[_], A, M, P](private val queue: JQueue[
 object JCAAEADPrimitive {
 
   private[tsec] def sync[F[_], A: BlockCipher: AEADCipher, M: CipherMode, P: SymmetricPadding](
-      queueSize: Int = 15
-  )(implicit F: Sync[F], ivProcess: IvProcess[A, M, P]): F[AADEncryptor[F, A, SecretKey]] =
-    F.delay(JCAPrimitiveCipher.genQueueUnsafe[A, M, P](queueSize))
-      .map(new JCAAEADPrimitive[F, A, M, P](_) {
-        def catchF[C](thunk: => C): F[C] = F.delay(thunk)
-      })
+      implicit F: Sync[F],
+      ivProcess: IvProcess[A, M, P]
+  ): AADEncryptor[F, A, SecretKey] =
+    new JCAAEADPrimitive[F, A, M, P] {
+      private[tsec] def catchF[C](thunk: => C): F[C] = F.delay(thunk)
+    }
 
   private[tsec] def monadError[F[_], A: BlockCipher: AEADCipher, M: CipherMode, P: SymmetricPadding](
-      queueSize: Int = 15
-  )(implicit F: MonadError[F, Throwable], ivProcess: IvProcess[A, M, P]): F[AADEncryptor[F, A, SecretKey]] =
-    F.catchNonFatal(JCAPrimitiveCipher.genQueueUnsafe[A, M, P](queueSize))
-      .map(
-        q =>
-          new JCAAEADPrimitive[F, A, M, P](q) {
-            def catchF[C](thunk: => C): F[C] =
-              F.catchNonFatal(thunk)
-        }
-      )
+      implicit F: MonadError[F, Throwable],
+      ivProcess: IvProcess[A, M, P]
+  ): JCAAEADPrimitive[F, A, M, P] =
+    new JCAAEADPrimitive[F, A, M, P] {
+      private[tsec] def catchF[C](thunk: => C): F[C] =
+        F.catchNonFatal(thunk)
+    }
 }

--- a/cipher-symmetric/src/main/scala/tsec/cipher/symmetric/jca/primitive/JCAPrimitiveCipher.scala
+++ b/cipher-symmetric/src/main/scala/tsec/cipher/symmetric/jca/primitive/JCAPrimitiveCipher.scala
@@ -1,6 +1,5 @@
 package tsec.cipher.symmetric.jca.primitive
 
-import java.util.concurrent.{ConcurrentLinkedQueue => JQueue}
 import javax.crypto.{Cipher => JCipher}
 
 import cats.MonadError
@@ -45,18 +44,6 @@ object JCAPrimitiveCipher {
       modeSpec: CipherMode[M],
       paddingTag: SymmetricPadding[P]
   ): JCipher = JCipher.getInstance(s"${algoTag.cipherName}/${modeSpec.mode}/${paddingTag.algorithm}")
-
-  private[tsec] def genQueueUnsafe[A: BlockCipher, M: CipherMode, P: SymmetricPadding](
-      queueLen: Int
-  ): JQueue[JCipher] = {
-    val q = new JQueue[JCipher]()
-    Array
-      .range(0, queueLen)
-      .foreach(
-        _ => q.add(getJCipherUnsafe)
-      )
-    q
-  }
 
   def sync[F[_], A: BlockCipher, M: CipherMode, P: SymmetricPadding](
       implicit F: Sync[F],

--- a/cipher-symmetric/src/test/scala/tsec/JCASymmetricSpec.scala
+++ b/cipher-symmetric/src/test/scala/tsec/JCASymmetricSpec.scala
@@ -4,9 +4,8 @@ import cats.effect.IO
 import org.scalatest.MustMatchers
 import org.scalatest.prop.PropertyChecks
 import tsec.cipher.common.padding._
+import tsec.cipher.symmetric._
 import tsec.cipher.symmetric.jca._
-import tsec.cipher.symmetric.jca.primitive.{JCAAEADPrimitive, JCAPrimitiveCipher}
-import tsec.cipher.symmetric.{Encryptor, IvGen, _}
 import tsec.common._
 import tsec.keygen.symmetric._
 
@@ -19,14 +18,13 @@ class JCASymmetricSpec extends TestSpec with MustMatchers with PropertyChecks {
       mode: CipherMode[M],
       p: SymmetricPadding[P],
       ivProcess: IvProcess[A, M, P],
-      S: SymmetricKeyGen[IO, A, SecretKey]
+      S: SymmetricKeyGen[IO, A, SecretKey],
+      E: Encryptor[IO, A, SecretKey]
   ): Unit = {
 
     val spec = s"""${symm.cipherName}_${symm.keySizeBytes * 8}/${mode.mode}/${p.algorithm}"""
 
     behavior of spec
-
-    implicit val instance: Encryptor[IO, A, SecretKey] = JCAPrimitiveCipher.sync[IO, A, M, P]().unsafeRunSync()
 
     implicit val defaultStrat: IvGen[IO, A] = JCAIvGen.random[IO, A]
 
@@ -88,12 +86,11 @@ class JCASymmetricSpec extends TestSpec with MustMatchers with PropertyChecks {
       mode: CipherMode[M],
       p: SymmetricPadding[P],
       ivProcess: IvProcess[A, M, P],
-      S: SymmetricKeyGen[IO, A, SecretKey]
+      S: SymmetricKeyGen[IO, A, SecretKey],
+      E: AADEncryptor[IO, A, SecretKey]
   ): Unit = {
 
     val spec = s"""${symm.cipherName}_${symm.keySizeBytes * 8}/${mode.mode}/${p.algorithm}"""
-
-    implicit val instance = JCAAEADPrimitive.sync[IO, A, M, P]().unsafeRunSync()
 
     implicit val defaultStrat = JCAIvGen.random[IO, A]
 

--- a/common/src/main/scala/tsec/cipher/symmetric/package.scala
+++ b/common/src/main/scala/tsec/cipher/symmetric/package.scala
@@ -66,6 +66,10 @@ package object symmetric {
     def tagSizeBytes: Int
   }
 
+  object AEADCipher{
+    def apply[A](implicit A: AEADCipher[A]): AEADCipher[A] = A
+  }
+
   /** In our implementation, we will use the most secure tag size as defined
     * by: http://nvlpubs.nist.gov/nistpubs/Legacy/SP/nistspecialpublication800-38d.pdf
     *  Iv length of 96 bits is recommended as per the spec on page 8

--- a/common/src/main/scala/tsec/common/CanCatch.scala
+++ b/common/src/main/scala/tsec/common/CanCatch.scala
@@ -1,5 +1,1 @@
 package tsec.common
-
-private[tsec] trait CanCatch[F[_]] {
-  def catchF[C](thunk: => C): F[C]
-}

--- a/common/src/main/scala/tsec/mac/MessageAuth.scala
+++ b/common/src/main/scala/tsec/mac/MessageAuth.scala
@@ -1,7 +1,7 @@
 package tsec.mac
 
 import cats.Functor
-import tsec.common.{VerificationFailed, VerificationStatus, Verified}
+import tsec.common.{CryptoTag, VerificationFailed, VerificationStatus, Verified}
 
 trait MessageAuth[F[_], A, K[_]] {
 

--- a/common/src/main/scala/tsec/mac/MessageAuth.scala
+++ b/common/src/main/scala/tsec/mac/MessageAuth.scala
@@ -5,6 +5,8 @@ import tsec.common.{VerificationFailed, VerificationStatus, Verified}
 
 trait MessageAuth[F[_], A, K[_]] {
 
+  def algorithm: String
+
   def sign(in: Array[Byte], key: K[A]): F[MAC[A]]
 
   def verifyBool(in: Array[Byte], hashed: MAC[A], key: K[A]): F[Boolean]

--- a/common/src/main/scala/tsec/signature/Signer.scala
+++ b/common/src/main/scala/tsec/signature/Signer.scala
@@ -5,6 +5,8 @@ import tsec.common.{VerificationFailed, VerificationStatus, Verified}
 
 trait Signer[F[_], A, PubK[_], PrivK[_]] {
 
+  def algorithm: String
+
   def sign(unsigned: Array[Byte], secretKey: PrivK[A]): F[CryptoSignature[A]]
 
   final def verify(raw: Array[Byte], signature: CryptoSignature[A], publicKey: PubK[A])(

--- a/docs/src/main/tut/docs/http4s/auth-ecookie.md
+++ b/docs/src/main/tut/docs/http4s/auth-ecookie.md
@@ -67,7 +67,7 @@ object EncryptedCookieExample {
 
   import http4sExamples.ExampleAuthHelpers._
 
-  implicit val encryptor   = AES128GCM.genEncryptor[IO].unsafeRunSync()
+  implicit val encryptor   = AES128GCM.genEncryptor[IO]
   implicit val gcmstrategy = AES128GCM.defaultIvStrategy[IO]
 
   val cookieBackingStore: BackingStore[IO, UUID, AuthEncryptedCookie[AES128GCM, Int]] =

--- a/docs/src/main/tut/motivation.md
+++ b/docs/src/main/tut/motivation.md
@@ -48,12 +48,10 @@ val toEncrypt = "Hello".utf8Bytes
 /** An authenticated encryption and decryption */
 implicit val gcmstrategy = AES128GCM.defaultIvStrategy[IO]
 
-val encryptAAD: IO[String] = AES128GCM.genEncryptor[IO].flatMap(
-  implicit instance =>
-    for {
-      key       <- AES128GCM.generateKey[IO]  //Generate our key
-      encrypted <- AES128GCM.encrypt[IO](PlainText(toEncrypt), key) //Encrypt
-      decrypted <- AES128GCM.decrypt[IO](encrypted, key)            //Decrypt
-    } yield decrypted.toUtf8String // "Hello!"
-) 
+val encryptAAD: IO[String] =
+  for {
+    key       <- AES128GCM.generateKey[IO]  //Generate our key
+    encrypted <- AES128GCM.encrypt[IO](PlainText(toEncrypt), key) //Encrypt
+    decrypted <- AES128GCM.decrypt[IO](encrypted, key)            //Decrypt
+  } yield decrypted.toUtf8String // "Hello!" 
 ```

--- a/examples/src/main/scala/SymmetricCipherExamples.scala
+++ b/examples/src/main/scala/SymmetricCipherExamples.scala
@@ -1,5 +1,3 @@
-
-
 object SymmetricCipherExamples {
 
   /** IMPORTANT NOTE: DO NOT SKIP
@@ -30,46 +28,36 @@ object SymmetricCipherExamples {
   val toEncrypt = "hi hello welcome to tsec".utf8Bytes
 
   implicit val ctrStrategy: IvGen[IO, AES128CTR] = AES128CTR.defaultIvStrategy[IO]
+  implicit val cachedInstance                    = AES128CTR.genEncryptor[IO] //Cache the implicit
 
-  val onlyEncrypt: IO[String] = AES128CTR
-    .genEncryptor[IO]
-    .flatMap(
-      implicit instance =>
-        for {
-          key       <- AES128CTR.generateKey[IO] //Generate our key
-          encrypted <- AES128CTR.encrypt[IO](PlainText(toEncrypt), key) //Encrypt our message
-          decrypted <- AES128CTR.decrypt[IO](encrypted, key)
-        } yield decrypted.toUtf8String
-    ) // "hi hello welcome to tsec!"
+  val onlyEncrypt: IO[String] =
+    for {
+      key       <- AES128CTR.generateKey[IO] //Generate our key
+      encrypted <- AES128CTR.encrypt[IO](PlainText(toEncrypt), key) //Encrypt our message
+      decrypted <- AES128CTR.decrypt[IO](encrypted, key)
+    } yield decrypted.toUtf8String // "hi hello welcome to tsec!"
 
   /** You can also turn it into a singular array with the IV concatenated at the end */
-  val onlyEncrypt2: IO[String] = AES128CTR
-    .genEncryptor[IO]
-    .flatMap(
-      implicit instance =>
-        for {
-          key       <- AES128CTR.generateKey[IO]                        //Generate our key
-          encrypted <- AES128CTR.encrypt[IO](PlainText(toEncrypt), key) //Encrypt our message
-          array = encrypted.toConcatenated
-          from      <- IO.fromEither(AES128CTR.ciphertextFromConcat(array))
-          decrypted <- AES128CTR.decrypt[IO](from, key)
-        } yield decrypted.toUtf8String
-    ) // "hi hello welcome to tsec!"
+  val onlyEncrypt2: IO[String] =
+    for {
+      key       <- AES128CTR.generateKey[IO]                        //Generate our key
+      encrypted <- AES128CTR.encrypt[IO](PlainText(toEncrypt), key) //Encrypt our message
+      array = encrypted.toConcatenated
+      from      <- IO.fromEither(AES128CTR.ciphertextFromConcat(array))
+      decrypted <- AES128CTR.decrypt[IO](from, key)
+    } yield decrypted.toUtf8String // "hi hello welcome to tsec!"
 
   /** An authenticated encryption and decryption */
-  implicit val gcmstrategy = AES128GCM.defaultIvStrategy[IO]
+  implicit val gcmstrategy        = AES128GCM.defaultIvStrategy[IO]
+  implicit val cachedAADEncryptor = AES128GCM.genEncryptor[IO]
 
   val aad = AAD("myAdditionalAuthenticationData".utf8Bytes)
-  val encryptAAD: IO[String] = AES128GCM
-    .genEncryptor[IO]
-    .flatMap(
-      implicit instance =>
-        for {
-          key       <- AES128GCM.generateKey[IO]                                    //Generate our key
-          encrypted <- AES128GCM.encryptWithAAD[IO](PlainText(toEncrypt), key, aad) //Encrypt
-          decrypted <- AES128GCM.decryptWithAAD[IO](encrypted, key, aad)            //Decrypt
-        } yield decrypted.toUtf8String
-    ) // "hi hello welcome to tsec!"
+  val encryptAAD: IO[String] =
+    for {
+      key       <- AES128GCM.generateKey[IO]                                    //Generate our key
+      encrypted <- AES128GCM.encryptWithAAD[IO](PlainText(toEncrypt), key, aad) //Encrypt
+      decrypted <- AES128GCM.decryptWithAAD[IO](encrypted, key, aad)            //Decrypt
+    } yield decrypted.toUtf8String // "hi hello welcome to tsec!"
 
   /** For more advanced usage, i.e you know which cipher you want specifically, you must import padding
     * as well as the low level package
@@ -80,9 +68,9 @@ object SymmetricCipherExamples {
   import tsec.cipher.common.padding._
   import tsec.cipher.symmetric.jca.primitive._
   val desStrategy = JCAIvGen.random[IO, DES]
+  implicit val instance = JCAPrimitiveCipher.sync[IO, DES, CBC, PKCS7Padding]
 
   val advancedUsage: IO[String] = for {
-    instance  <- JCAPrimitiveCipher.sync[IO, DES, CBC, PKCS7Padding]()
     key       <- DES.generateKey[IO]
     iv        <- desStrategy.genIv
     encrypted <- instance.encrypt(PlainText(toEncrypt), key, iv) //Encrypt our message, with our auth data

--- a/examples/src/main/scala/http4sExamples/EncryptedCookieExample.scala
+++ b/examples/src/main/scala/http4sExamples/EncryptedCookieExample.scala
@@ -16,7 +16,7 @@ object EncryptedCookieExample {
   import ExampleAuthHelpers._
   type AuthService = TSecAuthService[User, AuthEncryptedCookie[AES128GCM, Int], IO]
 
-  implicit val encryptor   = AES128GCM.genEncryptor[IO].unsafeRunSync()
+  implicit val encryptor   = AES128GCM.genEncryptor[IO]
   implicit val gcmstrategy = AES128GCM.defaultIvStrategy[IO]
 
   val cookieBackingStore: BackingStore[IO, UUID, AuthEncryptedCookie[AES128GCM, Int]] =

--- a/jwt-core/src/main/scala/tsec/jwt/algorithms/JWA.scala
+++ b/jwt-core/src/main/scala/tsec/jwt/algorithms/JWA.scala
@@ -4,7 +4,7 @@ import cats.MonadError
 import tsec.jwt.algorithms.JWTSigAlgo.MT
 import tsec.jwt.util.ParseEncodedKeySpec
 import tsec.mac.jca._
-import tsec.signature.jca.{JCASigTag, _}
+import tsec.signature.jca._
 
 sealed trait JWA[A] {
   val jwtRepr: String
@@ -56,12 +56,12 @@ object JWA {
 
 abstract class JWTMacAlgo[A] extends JWA[A]
 
-abstract class JWTSigAlgo[A: JCASigTag] extends JWA[A] {
+abstract class JWTSigAlgo[A] extends JWA[A] {
   def concatToJCA[F[_]](bytes: Array[Byte])(implicit me: MT[F]): F[Array[Byte]]
   def jcaToConcat[F[_]](bytes: Array[Byte])(implicit me: MT[F]): F[Array[Byte]]
 }
 
-abstract class JWTECSig[A: JCASigTag: ECKFTag] extends JWTSigAlgo[A] {
+abstract class JWTECSig[A: ECKFTag] extends JWTSigAlgo[A] {
 
   def concatToJCA[F[_]](bytes: Array[Byte])(implicit me: MT[F]): F[Array[Byte]] =
     ParseEncodedKeySpec.concatSignatureToDER[F, A](bytes)
@@ -71,9 +71,7 @@ abstract class JWTECSig[A: JCASigTag: ECKFTag] extends JWTSigAlgo[A] {
 
 }
 
-abstract class JWTRSASig[A: JCASigTag: RSAKFTag] extends JWTSigAlgo[A] {
-
-
+abstract class JWTRSASig[A: RSAKFTag] extends JWTSigAlgo[A] {
   def concatToJCA[F[_]](bytes: Array[Byte])(implicit me: MT[F]): F[Array[Byte]] = me.pure(bytes)
   def jcaToConcat[F[_]](bytes: Array[Byte])(implicit me: MT[F]): F[Array[Byte]] = me.pure(bytes)
 }

--- a/jwt-core/src/main/scala/tsec/jwt/util/ParseEncodedKeySpec.scala
+++ b/jwt-core/src/main/scala/tsec/jwt/util/ParseEncodedKeySpec.scala
@@ -8,7 +8,7 @@ import tsec.signature.jca._
 
 object ParseEncodedKeySpec {
 
-  def pubKeyFromBytes[F[_], A: JCASigTag](keyBytes: Array[Byte])(implicit kt: KFTag[A]): SigPublicKey[A] = {
+  def pubKeyFromBytes[F[_], A](keyBytes: Array[Byte])(implicit kt: KFTag[A]): SigPublicKey[A] = {
     val spec = new X509EncodedKeySpec(keyBytes)
     SigPublicKey[A](
       KeyFactory
@@ -17,7 +17,7 @@ object ParseEncodedKeySpec {
     )
   }
 
-  def privKeyFromBytes[F[_], A: JCASigTag](keyBytes: Array[Byte])(implicit kt: KFTag[A]): SigPrivateKey[A] = {
+  def privKeyFromBytes[F[_], A](keyBytes: Array[Byte])(implicit kt: KFTag[A]): SigPrivateKey[A] = {
     val spec = new PKCS8EncodedKeySpec(keyBytes)
     SigPrivateKey[A](
       KeyFactory

--- a/jwt-mac/src/main/scala/tsec/jws/mac/JWSMacCV.scala
+++ b/jwt-mac/src/main/scala/tsec/jws/mac/JWSMacCV.scala
@@ -108,14 +108,16 @@ sealed abstract class JWSMacCV[F[_], A](
 
 object JWSMacCV {
 
-  implicit def genSigner[F[_]: Sync, A: JCAMacTag](
-      implicit hs: JWSSerializer[JWSMacHeader[A]]
+  implicit def genSigner[F[_]: Sync, A](
+      implicit hs: JWSSerializer[JWSMacHeader[A]],
+    messageAuth: MessageAuth[F, A, MacSigningKey]
   ): JWSMacCV[F, A] =
     new JWSMacCV[F, A]() {}
 
-  implicit def eitherSigner[A: JCAMacTag](
-      implicit hs: JWSSerializer[JWSMacHeader[A]]
-  ): JWSMacCV[Either[Throwable, ?], A] =
+  implicit def eitherSigner[A](
+      implicit hs: JWSSerializer[JWSMacHeader[A]],
+    messageAuth: MessageAuth[MacErrorM, A, MacSigningKey]
+  ): JWSMacCV[MacErrorM, A] =
     new JWSMacCV[Either[Throwable, ?], A]() {}
 
 }

--- a/jwt-mac/src/main/scala/tsec/jws/mac/JWSMacHeader.scala
+++ b/jwt-mac/src/main/scala/tsec/jws/mac/JWSMacHeader.scala
@@ -10,7 +10,6 @@ import tsec.jws.header.JWSHeader
 import tsec.jwt
 import tsec.jwt.algorithms.JWTMacAlgo
 import tsec.jwt.header.JWTtyp
-import tsec.mac.jca.JCAMacTag
 
 /** A JWS header for JWT serialization.
   * TODO: Crit logic on verification
@@ -53,7 +52,7 @@ object JWSMacHeader {
     *
     * @see [[https://auth0.com/blog/critical-vulnerabilities-in-json-web-token-libraries/]]
     */
-  implicit def decoder[A: JCAMacTag: JWTMacAlgo]: Decoder[JWSMacHeader[A]] = new Decoder[JWSMacHeader[A]] {
+  implicit def decoder[A: JWTMacAlgo]: Decoder[JWSMacHeader[A]] = new Decoder[JWSMacHeader[A]] {
     def apply(c: HCursor): Either[DecodingFailure, JWSMacHeader[A]] =
       c.downField("alg")
         .as[String]

--- a/jwt-sig/src/main/scala/tsec/jws/signature/JWSSigCV.scala
+++ b/jwt-sig/src/main/scala/tsec/jws/signature/JWSSigCV.scala
@@ -13,7 +13,7 @@ import tsec.jwt.algorithms.JWTSigAlgo
 import tsec.signature._
 import tsec.signature.jca._
 
-sealed abstract class JWSSigCV[F[_], A: JCASigTag](
+sealed abstract class JWSSigCV[F[_], A](
     implicit hs: JWSSerializer[JWSSignedHeader[A]],
     jwsSigAlgo: JWTSigAlgo[A],
     sigDSL: JCASigner[F, A],
@@ -85,13 +85,15 @@ sealed abstract class JWSSigCV[F[_], A: JCASigTag](
 }
 
 object JWSSigCV {
-  implicit def genCVPure[F[_]: Sync, A: JCASigTag](
+  implicit def genCVPure[F[_]: Sync, A](
       implicit hs: JWSSerializer[JWSSignedHeader[A]],
+      signer: JCASigner[F, A],
       jwsSigAlgo: JWTSigAlgo[A]
   ): JWSSigCV[F, A] = new JWSSigCV[F, A]() {}
 
-  implicit def genCVImpure[A: JCASigTag](
+  implicit def genCVImpure[A](
       implicit hs: JWSSerializer[JWSSignedHeader[A]],
+      signer: JCASigner[SigErrorM, A],
       jwsSigAlgo: JWTSigAlgo[A]
   ): JWSSigCV[SigErrorM, A] = new JWSSigCV[SigErrorM, A]() {}
 }

--- a/mac/src/main/scala/tsec/mac/jca/JCAMessageAuth.scala
+++ b/mac/src/main/scala/tsec/mac/jca/JCAMessageAuth.scala
@@ -1,0 +1,27 @@
+package tsec.mac.jca
+
+import java.security.MessageDigest
+
+import cats.Monad
+import javax.crypto.{Mac, SecretKey}
+import tsec.mac.{MAC, MessageAuth}
+import cats.syntax.functor._
+import cats.syntax.flatMap._
+
+abstract class JCAMessageAuth[F[_], A](implicit F: Monad[F])
+  extends MessageAuth[F, A, MacSigningKey] {
+
+  protected[tsec] def genInstance: F[Mac]
+
+  protected[tsec] def signInternal(m: Mac, k: SecretKey, content: Array[Byte]): F[MAC[A]]
+
+  def sign(content: Array[Byte], key: MacSigningKey[A]): F[MAC[A]] =
+    for {
+      instance <- genInstance
+      fin      <- signInternal(instance, MacSigningKey.toJavaKey[A](key), content)
+    } yield fin
+
+  def verifyBool(toSign: Array[Byte], signed: MAC[A], key: MacSigningKey[A]): F[Boolean] =
+    F.map(sign(toSign, key))(MessageDigest.isEqual(signed, _))
+
+}

--- a/mac/src/main/scala/tsec/mac/jca/package.scala
+++ b/mac/src/main/scala/tsec/mac/jca/package.scala
@@ -21,19 +21,13 @@ package object jca {
 
   type MacKeyGen[F[_], A] = SymmetricKeyGen[F, A, MacSigningKey]
 
-  protected[tsec] trait JCAMacTag[T] extends CryptoTag[T]
-
-  object JCAMacTag {
-    @inline def apply[T](implicit M: JCAMacTag[T]): JCAMacTag[T] = M
-  }
-
   object MacSigningKey {
     type Base1
     trait Tag1 extends Any
     type Type[A] <: Base1 with Tag1
     @inline def apply[A](key: JSecretKey): MacSigningKey[A] = key.asInstanceOf[MacSigningKey[A]]
-    @inline def fromJavaKey[A: JCAMacTag](key: JSecretKey): MacSigningKey[A] = key.asInstanceOf[MacSigningKey[A]]
-    @inline def toJavaKey[A: JCAMacTag](key: MacSigningKey[A]): JSecretKey   = key.asInstanceOf[JSecretKey]
+    @inline def fromJavaKey[A](key: JSecretKey): MacSigningKey[A] = key.asInstanceOf[MacSigningKey[A]]
+    @inline def toJavaKey[A](key: MacSigningKey[A]): JSecretKey   = key.asInstanceOf[JSecretKey]
     def subst[A]: SKPartiallyApplied[A]                                      = new SKPartiallyApplied[A]()
 
     private[tsec] class SKPartiallyApplied[A](val dummy: Boolean = true) extends AnyVal {
@@ -48,69 +42,9 @@ package object jca {
   }
 
   final class SigningKeyOps[A](val key: MacSigningKey[A]) extends AnyVal {
-    def toJavaKey(implicit m: JCAMacTag[A]): JSecretKey = MacSigningKey.toJavaKey[A](key)
+    def toJavaKey: JSecretKey = MacSigningKey.toJavaKey[A](key)
   }
 
   implicit final def _macSigningOps[A](key: MacSigningKey[A]): SigningKeyOps[A] = new SigningKeyOps[A](key)
-
-  abstract class JCAMessageAuth[F[_]: Monad, A](tl: JQueue[Mac])(implicit macTag: JCAMacTag[A])
-      extends MessageAuth[F, A, MacSigningKey]
-      with CanCatch[F] {
-
-    private def genInstance: F[Mac] = catchF {
-      val inst: Mac = tl.poll()
-      if (inst != null)
-        inst
-      else
-        Mac.getInstance(macTag.algorithm)
-    }
-
-    def sign(content: Array[Byte], key: MacSigningKey[A]): F[MAC[A]] =
-      for {
-        instance <- genInstance
-        _        <- catchF(instance.init(MacSigningKey.toJavaKey[A](key)))
-        fin      <- catchF(instance.doFinal(content))
-        _        <- catchF(tl.add(instance))
-      } yield MAC[A](fin)
-
-    def verifyBool(toSign: Array[Byte], signed: MAC[A], key: MacSigningKey[A]): F[Boolean] =
-      sign(toSign, key).map(MessageDigest.isEqual(signed, _))
-
-  }
-
-  object JCAMessageAuth {
-    def sync[F[_], A](
-        numInstances: Int = 10
-    )(implicit tag: JCAMacTag[A], F: Sync[F]): JCAMessageAuth[F, A] = {
-      val queue = new JQueue[Mac]()
-      var i     = 0
-      while (i < numInstances) {
-        queue.add(Mac.getInstance(tag.algorithm))
-        i += 1
-      }
-      new JCAMessageAuth[F, A](queue) {
-        def catchF[C](thunk: => C): F[C] = F.delay(thunk)
-      }
-    }
-
-    def monadError[F[_], A](
-        numInstances: Int = 10
-    )(implicit tag: JCAMacTag[A], F: MonadError[F, Throwable]): JCAMessageAuth[F, A] = {
-      val queue = new JQueue[Mac]()
-      var i     = 0
-      while (i < numInstances) {
-        queue.add(Mac.getInstance(tag.algorithm))
-        i += 1
-      }
-      new JCAMessageAuth[F, A](queue) {
-        def catchF[C](thunk: => C): F[C] = F.catchNonFatal(thunk)
-      }
-    }
-
-  }
-
-  implicit def gen[F[_]: Sync, A: JCAMacTag]: JCAMessageAuth[F, A] = JCAMessageAuth.sync[F, A]()
-  implicit def genEither[A: JCAMacTag]: JCAMessageAuth[MacErrorM, A] =
-    JCAMessageAuth.monadError[MacErrorM, A]()
 
 }

--- a/mac/src/main/scala/tsec/mac/jca/package.scala
+++ b/mac/src/main/scala/tsec/mac/jca/package.scala
@@ -1,14 +1,6 @@
 package tsec.mac
 
-import java.security.MessageDigest
-import java.util.concurrent.{ConcurrentLinkedQueue => JQueue}
-import javax.crypto.{Mac, SecretKey => JSecretKey}
-
-import cats.effect.Sync
-import cats.instances.either._
-import cats.syntax.all._
-import cats.{Monad, MonadError}
-import tsec.common._
+import javax.crypto.{SecretKey => JSecretKey}
 import tsec.keygen.symmetric.{SymmetricKeyGen, SymmetricKeyGenAPI}
 
 package object jca {
@@ -25,10 +17,10 @@ package object jca {
     type Base1
     trait Tag1 extends Any
     type Type[A] <: Base1 with Tag1
-    @inline def apply[A](key: JSecretKey): MacSigningKey[A] = key.asInstanceOf[MacSigningKey[A]]
+    @inline def apply[A](key: JSecretKey): MacSigningKey[A]       = key.asInstanceOf[MacSigningKey[A]]
     @inline def fromJavaKey[A](key: JSecretKey): MacSigningKey[A] = key.asInstanceOf[MacSigningKey[A]]
     @inline def toJavaKey[A](key: MacSigningKey[A]): JSecretKey   = key.asInstanceOf[JSecretKey]
-    def subst[A]: SKPartiallyApplied[A]                                      = new SKPartiallyApplied[A]()
+    def subst[A]: SKPartiallyApplied[A]                           = new SKPartiallyApplied[A]()
 
     private[tsec] class SKPartiallyApplied[A](val dummy: Boolean = true) extends AnyVal {
       def apply[F[_]](value: F[JSecretKey]): F[MacSigningKey[A]] = value.asInstanceOf[F[MacSigningKey[A]]]

--- a/mac/src/test/scala/tsec/MacTests.scala
+++ b/mac/src/test/scala/tsec/MacTests.scala
@@ -6,16 +6,15 @@ import cats.effect.IO
 import org.scalatest.MustMatchers
 import tsec.common._
 import tsec.keygen.symmetric.SymmetricKeyGen
-import tsec.mac.jca.{JCAMacTag, _}
+import tsec.mac.jca._
 
 class MacTests extends TestSpec with MustMatchers {
 
   def macTest[A](
-      implicit tag: JCAMacTag[A],
-      keyGen: SymmetricKeyGen[IO, A, MacSigningKey],
+      implicit keyGen: SymmetricKeyGen[IO, A, MacSigningKey],
       pureinstance: JCAMessageAuth[IO, A]
   ): Unit = {
-    behavior of tag.algorithm
+    behavior of pureinstance.algorithm
 
     //Todo: Should be with scalacheck
     it should "Sign then verify the same encrypted data properly" in {

--- a/signatures/src/main/scala/tsec/signature/jca/JCASigInterpreter.scala
+++ b/signatures/src/main/scala/tsec/signature/jca/JCASigInterpreter.scala
@@ -4,10 +4,10 @@ import java.security.Signature
 
 import cats.effect.Sync
 
-sealed abstract class JCASigInterpreter[F[_], A](implicit M: Sync[F], signatureAlgorithm: JCASigTag[A])
+abstract class JCASigInterpreter[F[_], A](algorithm: String)(implicit M: Sync[F])
     extends JCASigAlgebra[F, A, SigPublicKey, SigPrivateKey, SigCertificate] {
 
-  def genSignatureInstance: F[Signature] = M.delay(Signature.getInstance(signatureAlgorithm.algorithm))
+  def genSignatureInstance: F[Signature] = M.delay(Signature.getInstance(algorithm))
 
   def initSign(instance: Signature, p: SigPrivateKey[A]): F[Unit] =
     M.delay(instance.initSign(SigPrivateKey.toJavaPrivateKey[A](p)))
@@ -23,13 +23,5 @@ sealed abstract class JCASigInterpreter[F[_], A](implicit M: Sync[F], signatureA
   def sign(instance: Signature): F[Array[Byte]] = M.delay(instance.sign())
 
   def verify(sig: Array[Byte], instance: Signature): F[Boolean] = M.delay(instance.verify(sig))
-
-}
-
-object JCASigInterpreter {
-
-  def apply[F[_]: Sync, A: JCASigTag]: JCASigInterpreter[F, A] = new JCASigInterpreter[F, A]() {}
-
-  implicit def genSig[F[_]: Sync, A: JCASigTag]: JCASigInterpreter[F, A] = apply[F, A]
 
 }

--- a/signatures/src/main/scala/tsec/signature/jca/JCASigInterpreterImpure.scala
+++ b/signatures/src/main/scala/tsec/signature/jca/JCASigInterpreterImpure.scala
@@ -5,12 +5,12 @@ import java.security.Signature
 import cats.syntax.either._
 import tsec.common.ErrorConstruct._
 
-sealed abstract class JCASigInterpreterImpure[A](implicit signatureAlgorithm: JCASigTag[A])
+abstract class JCASigInterpreterImpure[A](algorithm: String)
     extends JCASigAlgebra[SigErrorM, A, SigPublicKey, SigPrivateKey, SigCertificate] {
 
   def genSignatureInstance: SigErrorM[Signature] =
     Either
-      .catchNonFatal(Signature.getInstance(signatureAlgorithm.algorithm))
+      .catchNonFatal(Signature.getInstance(algorithm))
       .mapError(SignatureInitError.apply)
 
   def initSign(instance: Signature, p: SigPrivateKey[A]): SigErrorM[Unit] =
@@ -32,10 +32,4 @@ sealed abstract class JCASigInterpreterImpure[A](implicit signatureAlgorithm: JC
 
   def verify(sig: Array[Byte], instance: Signature): SigErrorM[Boolean] =
     Either.catchNonFatal(instance.verify(sig)).mapError(SignatureVerificationError.apply)
-}
-
-object JCASigInterpreterImpure {
-
-  implicit def genSig[A: JCASigTag]: JCASigInterpreterImpure[A] = new JCASigInterpreterImpure[A]() {}
-
 }

--- a/signatures/src/main/scala/tsec/signature/jca/JCASigTag.scala
+++ b/signatures/src/main/scala/tsec/signature/jca/JCASigTag.scala
@@ -1,5 +1,0 @@
-package tsec.signature.jca
-
-import tsec.common.CryptoTag
-
-trait JCASigTag[A] extends CryptoTag[A]

--- a/signatures/src/main/scala/tsec/signature/jca/JCASigner.scala
+++ b/signatures/src/main/scala/tsec/signature/jca/JCASigner.scala
@@ -1,0 +1,36 @@
+package tsec.signature.jca
+
+import cats.Monad
+import tsec.signature.{CertificateSigner, CryptoSignature}
+import cats.syntax.functor._
+import cats.syntax.flatMap._
+
+abstract class JCASigner[F[_]: Monad, A](
+    algebra: JCASigAlgebra[F, A, SigPublicKey, SigPrivateKey, SigCertificate]
+) extends CertificateSigner[F, A, SigPublicKey, SigPrivateKey, SigCertificate] {
+
+  def sign(content: Array[Byte], p: SigPrivateKey[A]): F[CryptoSignature[A]] =
+    for {
+      instance <- algebra.genSignatureInstance
+      _        <- algebra.initSign(instance, p)
+      _        <- algebra.loadBytes(content, instance)
+      signed   <- algebra.sign(instance)
+    } yield CryptoSignature[A](signed)
+
+  def verifyBool(toSign: Array[Byte], signed: CryptoSignature[A], k: SigPublicKey[A]): F[Boolean] =
+    for {
+      instance <- algebra.genSignatureInstance
+      _        <- algebra.initVerifyK(instance, k)
+      _        <- algebra.loadBytes(toSign, instance)
+      verified <- algebra.verify(signed, instance)
+    } yield verified
+
+  def verifyCert(toSign: Array[Byte], signed: CryptoSignature[A], c: SigCertificate[A]): F[Boolean] =
+    for {
+      instance <- algebra.genSignatureInstance
+      _        <- algebra.initVerifyC(instance, c)
+      _        <- algebra.loadBytes(toSign, instance)
+      verified <- algebra.verify(signed, instance)
+    } yield verified
+
+}

--- a/signatures/src/main/scala/tsec/signature/jca/SigKeyPair.scala
+++ b/signatures/src/main/scala/tsec/signature/jca/SigKeyPair.scala
@@ -5,6 +5,6 @@ import java.security.KeyPair
 case class SigKeyPair[A](privateKey: SigPrivateKey[A], publicKey: SigPublicKey[A])
 
 object SigKeyPair {
-  def fromKeyPair[A: JCASigTag](keypair: KeyPair): SigKeyPair[A] =
+  def fromKeyPair[A](keypair: KeyPair): SigKeyPair[A] =
     SigKeyPair[A](SigPrivateKey[A](keypair.getPrivate), SigPublicKey[A](keypair.getPublic))
 }

--- a/signatures/src/main/scala/tsec/signature/jca/package.scala
+++ b/signatures/src/main/scala/tsec/signature/jca/package.scala
@@ -3,11 +3,6 @@ package tsec.signature
 import java.security.{PrivateKey, PublicKey}
 import java.security.cert.Certificate
 
-import cats.Monad
-import cats.effect.Sync
-import cats.instances.either._
-import cats.syntax.all._
-
 package object jca {
   type SigErrorM[A] = Either[Throwable, A]
 
@@ -16,7 +11,7 @@ package object jca {
   object SigCertificate {
     type Repr[A]
 
-    @inline def apply[A: JCASigTag](cert: Certificate): SigCertificate[A]  = cert.asInstanceOf[SigCertificate[A]]
+    @inline def apply[A](cert: Certificate): SigCertificate[A]  = cert.asInstanceOf[SigCertificate[A]]
     @inline def toJavaCertificate[A](cert: SigCertificate[A]): Certificate = cert.asInstanceOf[Certificate]
   }
 
@@ -25,7 +20,7 @@ package object jca {
   object SigPublicKey {
     type Repr[A]
 
-    @inline def apply[A: JCASigTag](key: PublicKey): SigPublicKey[A] = key.asInstanceOf[SigPublicKey[A]]
+    @inline def apply[A](key: PublicKey): SigPublicKey[A] = key.asInstanceOf[SigPublicKey[A]]
     @inline def toJavaPublicKey[A](key: SigPublicKey[A]): PublicKey  = key.asInstanceOf[PublicKey]
   }
 
@@ -34,45 +29,16 @@ package object jca {
   object SigPrivateKey {
     type Repr[A]
 
-    @inline def apply[A: JCASigTag](key: PrivateKey): SigPrivateKey[A] = key.asInstanceOf[SigPrivateKey[A]]
+    @inline def apply[A](key: PrivateKey): SigPrivateKey[A] = key.asInstanceOf[SigPrivateKey[A]]
     @inline def toJavaPrivateKey[A](key: SigPrivateKey[A]): PrivateKey = key.asInstanceOf[PrivateKey]
   }
 
-  class JCASigner[F[_]: Monad, A: JCASigTag](
-      algebra: JCASigAlgebra[F, A, SigPublicKey, SigPrivateKey, SigCertificate]
-  ) extends CertificateSigner[F, A, SigPublicKey, SigPrivateKey, SigCertificate] {
 
-    def sign(content: Array[Byte], p: SigPrivateKey[A]): F[CryptoSignature[A]] =
-      for {
-        instance <- algebra.genSignatureInstance
-        _        <- algebra.initSign(instance, p)
-        _        <- algebra.loadBytes(content, instance)
-        signed   <- algebra.sign(instance)
-      } yield CryptoSignature[A](signed)
-
-    def verifyBool(toSign: Array[Byte], signed: CryptoSignature[A], k: SigPublicKey[A]): F[Boolean] =
-      for {
-        instance <- algebra.genSignatureInstance
-        _        <- algebra.initVerifyK(instance, k)
-        _        <- algebra.loadBytes(toSign, instance)
-        verified <- algebra.verify(signed, instance)
-      } yield verified
-
-    def verifyCert(toSign: Array[Byte], signed: CryptoSignature[A], c: SigCertificate[A]): F[Boolean] =
-      for {
-        instance <- algebra.genSignatureInstance
-        _        <- algebra.initVerifyC(instance, c)
-        _        <- algebra.loadBytes(toSign, instance)
-        verified <- algebra.verify(signed, instance)
-      } yield verified
-
-  }
-
-  implicit def signer[F[_]: Sync, A: JCASigTag](
-      implicit C: JCASigInterpreter[F, A]
-  ): JCASigner[F, A] = new JCASigner[F, A](C)
-
-  implicit def impureSigner[A: JCASigTag](implicit jCASigner: JCASigInterpreterImpure[A]): JCASigner[SigErrorM, A] =
-    new JCASigner(jCASigner)
+//  implicit def signer[F[_]: Sync, A](
+//      implicit C: JCASigInterpreter[F, A]
+//  ): JCASigner[F, A] = new JCASigner[F, A](C)
+//
+//  implicit def impureSigner[A](implicit jCASigner: JCASigInterpreterImpure[A]): JCASigner[SigErrorM, A] =
+//    new JCASigner(jCASigner)
 
 }

--- a/signatures/src/test/scala/tsec/SignatureTests.scala
+++ b/signatures/src/test/scala/tsec/SignatureTests.scala
@@ -11,12 +11,11 @@ class SignatureTests extends TestSpec with MustMatchers {
   val toSign = "HItHERE!".utf8Bytes
 
   def sigIOTests[A](
-      implicit algoTag: JCASigTag[A],
-      interp: JCASigner[IO, A],
+      implicit interp: JCASigner[IO, A],
       ecKFTag: JCASigKG[IO, A]
   ): Unit = {
 
-    behavior of s"${algoTag.algorithm}"
+    behavior of s"${interp.algorithm}"
 
     it should "sign and verify properly for correct keypair" in {
 

--- a/tsec-http4s/src/main/scala/tsec/authentication/JWTAuthenticator.scala
+++ b/tsec-http4s/src/main/scala/tsec/authentication/JWTAuthenticator.scala
@@ -13,7 +13,7 @@ import tsec.authentication.internal._
 import tsec.common._
 import tsec.jws.mac._
 import tsec.jwt.algorithms.JWTMacAlgo
-import tsec.mac.jca.{JCAMacTag, MacSigningKey}
+import tsec.mac.jca.{MacSigningKey}
 
 import scala.concurrent.duration.FiniteDuration
 
@@ -61,7 +61,7 @@ object JWTAuthenticator {
   /** Create a JWT Authenticator that will transport it as a
     * bearer token
     */
-  private[tsec] def backingStore[F[_], I, V, A: JWTMacAlgo: JCAMacTag](
+  private[tsec] def backingStore[F[_], I, V, A: JWTMacAlgo](
       expiryDuration: FiniteDuration,
       maxIdle: Option[FiniteDuration],
       tokenStore: BackingStore[F, SecureRandomId, AugmentedJWT[A, I]],
@@ -127,7 +127,7 @@ object JWTAuthenticator {
         }
     }
 
-  private[tsec] def partialStateless[F[_], I: Decoder: Encoder, V, A: JWTMacAlgo: JCAMacTag](
+  private[tsec] def partialStateless[F[_], I: Decoder: Encoder, V, A: JWTMacAlgo](
       expiry: FiniteDuration,
       maxIdle: Option[FiniteDuration],
       identityStore: IdentityStore[F, I, V],
@@ -184,7 +184,7 @@ object JWTAuthenticator {
         }
     }
 
-  private[tsec] def embedded[F[_], V: Decoder: ObjectEncoder, A: JWTMacAlgo: JCAMacTag](
+  private[tsec] def embedded[F[_], V: Decoder: ObjectEncoder, A: JWTMacAlgo](
       expiryDuration: FiniteDuration,
       maxIdle: Option[FiniteDuration],
       signingKey: MacSigningKey[A],
@@ -260,7 +260,7 @@ object JWTAuthenticator {
     /** Create a JWT Authenticator that will transport it as a
       * bearer token
       */
-    def inBearerToken[F[_], I, V, A: JWTMacAlgo: JCAMacTag](
+    def inBearerToken[F[_], I, V, A: JWTMacAlgo](
         expiryDuration: FiniteDuration,
         maxIdle: Option[FiniteDuration],
         tokenStore: BackingStore[F, SecureRandomId, AugmentedJWT[A, I]],
@@ -281,7 +281,7 @@ object JWTAuthenticator {
       * an arbitrary header, with a backing store.
       *
       */
-    def inHeader[F[_], I, V, A: JWTMacAlgo: JCAMacTag](
+    def inHeader[F[_], I, V, A: JWTMacAlgo](
         settings: TSecJWTSettings,
         tokenStore: BackingStore[F, SecureRandomId, AugmentedJWT[A, I]],
         identityStore: IdentityStore[F, I, V],
@@ -301,7 +301,7 @@ object JWTAuthenticator {
       * an arbitrary header, with a backing store.
       *
       */
-    def inCookie[F[_], I, V, A: JWTMacAlgo: JCAMacTag](
+    def inCookie[F[_], I, V, A: JWTMacAlgo](
         settings: TSecCookieSettings,
         tokenStore: BackingStore[F, SecureRandomId, AugmentedJWT[A, I]],
         identityStore: IdentityStore[F, I, V],
@@ -323,7 +323,7 @@ object JWTAuthenticator {
     /** Create a JWT Authenticator that will transport it as a
       * bearer token
       */
-    def inBearerToken[F[_], I: Decoder: Encoder, V, A: JWTMacAlgo: JCAMacTag](
+    def inBearerToken[F[_], I: Decoder: Encoder, V, A: JWTMacAlgo](
         expiryDuration: FiniteDuration,
         maxIdle: Option[FiniteDuration],
         identityStore: IdentityStore[F, I, V],
@@ -342,7 +342,7 @@ object JWTAuthenticator {
       * an arbitrary header, with a backing store.
       *
       */
-    def inHeader[F[_], I: Decoder: Encoder, V, A: JWTMacAlgo: JCAMacTag](
+    def inHeader[F[_], I: Decoder: Encoder, V, A: JWTMacAlgo](
         settings: TSecJWTSettings,
         identityStore: IdentityStore[F, I, V],
         signingKey: MacSigningKey[A]
@@ -360,7 +360,7 @@ object JWTAuthenticator {
       * an arbitrary header, with a backing store.
       *
       */
-    def inCookie[F[_], I: Decoder: Encoder, V, A: JWTMacAlgo: JCAMacTag](
+    def inCookie[F[_], I: Decoder: Encoder, V, A: JWTMacAlgo](
         settings: TSecCookieSettings,
         identityStore: IdentityStore[F, I, V],
         signingKey: MacSigningKey[A]
@@ -380,7 +380,7 @@ object JWTAuthenticator {
     /** Create a JWT Authenticator that will transport it as a
       * bearer token
       */
-    def inBearerToken[F[_], V: Decoder: ObjectEncoder, A: JWTMacAlgo: JCAMacTag](
+    def inBearerToken[F[_], V: Decoder: ObjectEncoder, A: JWTMacAlgo](
         expiryDuration: FiniteDuration,
         maxIdle: Option[FiniteDuration],
         signingKey: MacSigningKey[A]
@@ -397,7 +397,7 @@ object JWTAuthenticator {
       * an arbitrary header, with a backing store.
       *
       */
-    def inHeader[F[_], V: Decoder: ObjectEncoder, A: JWTMacAlgo: JCAMacTag](
+    def inHeader[F[_], V: Decoder: ObjectEncoder, A: JWTMacAlgo](
         settings: TSecJWTSettings,
         signingKey: MacSigningKey[A]
     )(implicit cv: JWSMacCV[F, A], F: Sync[F]): JWTAuthenticator[F, V, V, A] =
@@ -413,7 +413,7 @@ object JWTAuthenticator {
       * an arbitrary header, with a backing store.
       *
       */
-    def inCookie[F[_], V: Decoder: ObjectEncoder, A: JWTMacAlgo: JCAMacTag](
+    def inCookie[F[_], V: Decoder: ObjectEncoder, A: JWTMacAlgo](
         settings: TSecCookieSettings,
         signingKey: MacSigningKey[A]
     )(implicit cv: JWSMacCV[F, A], F: Sync[F]): JWTAuthenticator[F, V, V, A] =

--- a/tsec-http4s/src/main/scala/tsec/csrf/TSecCSRF.scala
+++ b/tsec-http4s/src/main/scala/tsec/csrf/TSecCSRF.scala
@@ -10,7 +10,7 @@ import org.http4s.util.CaseInsensitiveString
 import org.http4s.{Cookie, HttpService, Request, Response, Status}
 import tsec.authentication.{cookieFromRequest, unliftedCookieFromRequest}
 import tsec.common._
-import tsec.mac.jca.{JCAMacTag, JCAMessageAuth, _}
+import tsec.mac.jca.{JCAMessageAuth, _}
 
 /** Middleware to avoid Cross-site request forgery attacks.
   * More info on CSRF at: https://www.owasp.org/index.php/Cross-Site_Request_Forgery_(CSRF)
@@ -42,7 +42,7 @@ import tsec.mac.jca.{JCAMacTag, JCAMessageAuth, _}
   * @param key the CSRF signing key
   * @param clock clock used as a nonce
   */
-final class TSecCSRF[F[_], A: JCAMacTag] private[tsec] (
+final class TSecCSRF[F[_], A] private[tsec] (
     key: MacSigningKey[A],
     val headerName: String,
     val cookieName: String,
@@ -132,12 +132,12 @@ final class TSecCSRF[F[_], A: JCAMacTag] private[tsec] (
 }
 
 object TSecCSRF {
-  def apply[F[_]: Sync, A: JCAMacTag](
+  def apply[F[_]: Sync, A](
       key: MacSigningKey[A],
       headerName: String = "X-TSec-Csrf",
       cookieName: String = "tsec-csrf",
       tokenLength: Int = 32,
       clock: Clock = Clock.systemUTC()
-  ): TSecCSRF[F, A] =
+  )(implicit M: JCAMessageAuth[F, A]): TSecCSRF[F, A] =
     new TSecCSRF[F, A](key, headerName, cookieName, tokenLength, clock)
 }

--- a/tsec-http4s/src/test/scala/tsec/AEADCookieSignerTest.scala
+++ b/tsec-http4s/src/test/scala/tsec/AEADCookieSignerTest.scala
@@ -14,7 +14,7 @@ class AEADCookieSignerTest extends TestSpec with MustMatchers with PropertyCheck
   def aeadCookieTest[A](implicit api: AESGCM[A], keyGen: SymmetricKeyGen[IO, A, SecretKey]): Unit = {
     implicit val strategy = api.defaultIvStrategy[IO]
 
-    implicit val instance = api.genEncryptor[IO].unsafeRunSync()
+    implicit val instance: AADEncryptor[IO, A, SecretKey] = api.genEncryptor[IO]
 
     behavior of s"AEAD Cookie encrypting with ${api.cipherName}${api.keySizeBytes * 8}"
 

--- a/tsec-http4s/src/test/scala/tsec/CookieSignerTests.scala
+++ b/tsec-http4s/src/test/scala/tsec/CookieSignerTests.scala
@@ -6,16 +6,17 @@ import org.scalacheck.{Arbitrary, Gen}
 import org.scalatest.MustMatchers
 import org.scalatest.prop.PropertyChecks
 import tsec.cookies.CookieSigner
-import tsec.mac.jca.{JCAMacTag, _}
+import tsec.mac.jca._
 import cats.instances.either._
 import cats.syntax.either._
+import tsec.mac.MessageAuth
 
 class CookieSignerTests extends TestSpec with MustMatchers with PropertyChecks {
 
   implicit val arbitraryUUID: Arbitrary[UUID] = Arbitrary.apply(Gen.uuid)
 
-  def signerTests[A](implicit tag: JCAMacTag[A], keyGen: MacKeyGen[MacErrorM, A]) = {
-    behavior of "CookieSigner for algo " + tag.algorithm
+  def signerTests[A](implicit M: MessageAuth[MacErrorM, A, MacSigningKey], keyGen: MacKeyGen[MacErrorM, A]) = {
+    behavior of "CookieSigner for algo " + M.algorithm
 
     it should "Sign and verify any cookie properly with coercion" in {
       forAll { (s: String) =>

--- a/tsec-http4s/src/test/scala/tsec/authentication/CSRFSpec.scala
+++ b/tsec-http4s/src/test/scala/tsec/authentication/CSRFSpec.scala
@@ -8,7 +8,7 @@ import org.scalatest.MustMatchers
 import tsec.TestSpec
 import tsec.csrf.{CSRFToken, TSecCSRF}
 import tsec.keygen.symmetric.IdKeyGen
-import tsec.mac.jca.{JCAMacTag, _}
+import tsec.mac.jca._
 
 class CSRFSpec extends TestSpec with MustMatchers {
 
@@ -25,8 +25,8 @@ class CSRFSpec extends TestSpec with MustMatchers {
   val passThroughRequest: Request[IO] = Request[IO]()
   val orElse: Response[IO]            = Response[IO](Status.Unauthorized)
 
-  def testCSRFWithMac[A: JCAMacTag](implicit keygen: IdKeyGen[A, MacSigningKey]) = {
-    behavior of s"CSRF signing using " + JCAMacTag[A].algorithm
+  def testCSRFWithMac[A](implicit mac: JCAMessageAuth[IO, A], keygen: IdKeyGen[A, MacSigningKey]) = {
+    behavior of s"CSRF signing using " + mac.algorithm
 
     val newKey   = keygen.generateKey
     val tsecCSRF = TSecCSRF[IO, A](newKey)
@@ -46,7 +46,7 @@ class CSRFSpec extends TestSpec with MustMatchers {
       } yield eq).getOrElse(false).unsafeRunSync() mustBe false
     }
 
-    behavior of s"CSRF middleware using " + JCAMacTag[A].algorithm
+    behavior of s"CSRF middleware using " + mac.algorithm
 
     it should "pass through and embed for a fresh request in a safe method" in {
 

--- a/tsec-http4s/src/test/scala/tsec/authentication/EncryptedCookieAuthenticatorSpec.scala
+++ b/tsec-http4s/src/test/scala/tsec/authentication/EncryptedCookieAuthenticatorSpec.scala
@@ -27,7 +27,7 @@ class EncryptedCookieAuthenticatorSpec extends RequestAuthenticatorSpec {
       idKeyGen: IdKeyGen[A, SecretKey],
       store: BackingStore[IO, UUID, AuthEncryptedCookie[A, Int]]
   ): AuthSpecTester[AuthEncryptedCookie[A, Int]] = {
-    implicit val instance = cipherAPI.genEncryptor[IO].unsafeRunSync()
+    implicit val instance = cipherAPI.genEncryptor[IO]
     implicit val stategy  = cipherAPI.defaultIvStrategy[IO]
 
     val dummyStore = dummyBackingStore[IO, Int, DummyUser](_.id)
@@ -70,7 +70,7 @@ class EncryptedCookieAuthenticatorSpec extends RequestAuthenticatorSpec {
       implicit cipherAPI: AESGCM[A],
       idKeyGen: IdKeyGen[A, SecretKey]
   ): AuthSpecTester[AuthEncryptedCookie[A, Int]] = {
-    implicit val instance = cipherAPI.genEncryptor[IO].unsafeRunSync()
+    implicit val instance = cipherAPI.genEncryptor[IO]
     implicit val stategy  = cipherAPI.defaultIvStrategy[IO]
 
     val dummyStore = dummyBackingStore[IO, Int, DummyUser](_.id)

--- a/tsec-http4s/src/test/scala/tsec/authentication/JWTAuthenticatorSpec.scala
+++ b/tsec-http4s/src/test/scala/tsec/authentication/JWTAuthenticatorSpec.scala
@@ -88,7 +88,7 @@ class JWTAuthenticatorSpec extends RequestAuthenticatorSpec {
   /** Stateful tests using Authorization: Header
     *
     */
-  def stateful[A: JWTMacAlgo: JCAMacTag](tf: BackedAuth[A], embedder: Embedder[A])(
+  def stateful[A: JWTMacAlgo](tf: BackedAuth[A], embedder: Embedder[A])(
       implicit cv: JWSMacCV[IO, A],
       macKeyGen: IdKeyGen[A, MacSigningKey],
       store: BackingStore[IO, SecureRandomId, AugmentedJWT[A, Int]]
@@ -127,7 +127,7 @@ class JWTAuthenticatorSpec extends RequestAuthenticatorSpec {
   /** Unencrypted stateless in bearer tests
     *
     */
-  def partialStateless[A: JWTMacAlgo: JCAMacTag](tf: UnBackedAuth[A], embedder: Embedder[A])(
+  def partialStateless[A: JWTMacAlgo](tf: UnBackedAuth[A], embedder: Embedder[A])(
       implicit cv: JWSMacCV[IO, A],
       macKeyGen: IdKeyGen[A, MacSigningKey]
   ): AuthSpecTester[AugmentedJWT[A, Int]] = {
@@ -164,7 +164,7 @@ class JWTAuthenticatorSpec extends RequestAuthenticatorSpec {
   /** Unencrypted stateless in bearer tests
     *
     */
-  def stateless[A: JWTMacAlgo: JCAMacTag](tf: StatelessAuth[A], embedder: StatelessEmbedder[A])(
+  def stateless[A: JWTMacAlgo](tf: StatelessAuth[A], embedder: StatelessEmbedder[A])(
       implicit cv: JWSMacCV[IO, A],
       macKeyGen: IdKeyGen[A, MacSigningKey]
   ): StatelessSpecTester[AugmentedJWT[A, DummyUser]] = {

--- a/tsec-http4s/src/test/scala/tsec/authentication/JWTAuthenticatorTests.scala
+++ b/tsec-http4s/src/test/scala/tsec/authentication/JWTAuthenticatorTests.scala
@@ -9,7 +9,8 @@ import tsec.jws.mac.{JWSMacCV, JWTMac}
 import tsec.jwt.JWTClaims
 import tsec.jwt.algorithms.JWTMacAlgo
 import tsec.keygen.symmetric.IdKeyGen
-import tsec.mac.jca.{JCAMacTag, _}
+import tsec.mac.MessageAuth
+import tsec.mac.jca._
 
 class JWTAuthenticatorTests extends JWTAuthenticatorSpec with PropertyChecks {
 
@@ -17,9 +18,9 @@ class JWTAuthenticatorTests extends JWTAuthenticatorSpec with PropertyChecks {
 
   /** backed **/
   def runStatefulAuthenticators[A: JWTMacAlgo](
-      implicit cv: JWSMacCV[IO, A],
-      macKeyGen: IdKeyGen[A, MacSigningKey],
-      M: JCAMacTag[A]
+      implicit M: MessageAuth[IO, A, MacSigningKey],
+      cv: JWSMacCV[IO, A],
+      macKeyGen: IdKeyGen[A, MacSigningKey]
   ) =
     List[JWTTestingGroup[BackedAuth[A], Embedder[A]]](
       JWTTestingGroup(
@@ -98,9 +99,9 @@ class JWTAuthenticatorTests extends JWTAuthenticatorSpec with PropertyChecks {
 
   /** backed **/
   def runPartialStatelessAuthenticators[A: JWTMacAlgo](
-      implicit cv: JWSMacCV[IO, A],
-      macKeyGen: IdKeyGen[A, MacSigningKey],
-      M: JCAMacTag[A]
+      implicit M: MessageAuth[IO, A, MacSigningKey],
+      cv: JWSMacCV[IO, A],
+      macKeyGen: IdKeyGen[A, MacSigningKey]
   ) =
     List[JWTTestingGroup[UnBackedAuth[A], Embedder[A]]](
       JWTTestingGroup(
@@ -173,9 +174,9 @@ class JWTAuthenticatorTests extends JWTAuthenticatorSpec with PropertyChecks {
 
   /** backed **/
   def runStatelessAuthenticators[A: JWTMacAlgo](
-      implicit cv: JWSMacCV[IO, A],
-      macKeyGen: IdKeyGen[A, MacSigningKey],
-      M: JCAMacTag[A]
+      implicit M: MessageAuth[IO, A, MacSigningKey],
+      cv: JWSMacCV[IO, A],
+      macKeyGen: IdKeyGen[A, MacSigningKey]
   ) =
     List[JWTTestingGroup[StatelessAuth[A], StatelessEmbedder[A]]](
       JWTTestingGroup(
@@ -240,8 +241,12 @@ class JWTAuthenticatorTests extends JWTAuthenticatorSpec with PropertyChecks {
     }
 
   /** End Stateless Encrypted Auth Bearer Header Tests **/
-  def checkAuthHeader[A: JWTMacAlgo: JCAMacTag](implicit cv: JWSMacCV[IO, A], macKeyGen: MacKeyGen[IO, A]) = {
-    behavior of JCAMacTag[A].algorithm + " JWT Token64 check"
+  def checkAuthHeader[A: JWTMacAlgo](
+      implicit M: MessageAuth[IO, A, MacSigningKey],
+      cv: JWSMacCV[IO, A],
+      macKeyGen: MacKeyGen[IO, A]
+  ) = {
+    behavior of M.algorithm + " JWT Token64 check"
     macKeyGen.generateKey
       .map { key =>
         it should "pass token68 check" in {

--- a/tsec-libsodium/src/main/scala/tsec/mac/libsodium/HS256.scala
+++ b/tsec-libsodium/src/main/scala/tsec/mac/libsodium/HS256.scala
@@ -5,7 +5,7 @@ import tsec.mac._
 
 sealed trait HS256
 
-object HS256 extends SodiumMacPlatform[HS256] {
+object HS256 extends SodiumMacPlatform[HS256]("HS256") {
   val keyLen: Int       = ScalaSodium.crypto_auth_hmacsha256_KEYBYTES
   val macLen: Int       = ScalaSodium.crypto_auth_hmacsha256_BYTES
   val algorithm: String = "HMACSHA256"

--- a/tsec-libsodium/src/main/scala/tsec/mac/libsodium/HS512.scala
+++ b/tsec-libsodium/src/main/scala/tsec/mac/libsodium/HS512.scala
@@ -5,7 +5,7 @@ import tsec.mac._
 
 sealed trait HS512
 
-object HS512 extends SodiumMacPlatform[HS512] {
+object HS512 extends SodiumMacPlatform[HS512]("HS512") {
   val keyLen: Int       = ScalaSodium.crypto_auth_hmacsha512_KEYBYTES
   val macLen: Int       = ScalaSodium.crypto_auth_hmacsha512_BYTES
   val algorithm: String = "HMACSHA512"

--- a/tsec-libsodium/src/main/scala/tsec/mac/libsodium/SodiumMacPlatform.scala
+++ b/tsec-libsodium/src/main/scala/tsec/mac/libsodium/SodiumMacPlatform.scala
@@ -5,7 +5,7 @@ import tsec.keygen.symmetric.SymmetricKeyGen
 import tsec.libsodium.ScalaSodium
 import tsec.mac.{MessageAuth, _}
 
-private[tsec] trait SodiumMacPlatform[A] extends SodiumMacAlgo[A] with SodiumMacAPI[A] {
+private[tsec] abstract class SodiumMacPlatform[A](algo: String) extends SodiumMacAlgo[A] with SodiumMacAPI[A] {
   implicit val sm: SodiumMacAlgo[A]        = this
   implicit val macAlgebra: SodiumMacAPI[A] = this
 
@@ -19,6 +19,9 @@ private[tsec] trait SodiumMacPlatform[A] extends SodiumMacAlgo[A] with SodiumMac
 
   implicit def authenticator[F[_]](implicit F: Sync[F], S: ScalaSodium): MessageAuth[F, A, SodiumMACKey] =
     new MessageAuth[F, A, SodiumMACKey] {
+
+      def algorithm: String = algo
+
       def sign(in: Array[Byte], key: SodiumMACKey[A]): F[MAC[A]] =
         F.delay(impl.sign(in, key))
 

--- a/tsec-libsodium/src/main/scala/tsec/signature/libsodium/Ed25519Sig.scala
+++ b/tsec-libsodium/src/main/scala/tsec/signature/libsodium/Ed25519Sig.scala
@@ -20,6 +20,9 @@ object Ed25519Sig
 
   implicit def genSigner[F[_]](implicit F: Sync[F], S: ScalaSodium): Signer[F, Ed25519Sig, PublicKey, PrivateKey] =
     new Signer[F, Ed25519Sig, PublicKey, PrivateKey] {
+
+      lazy val algorithm: String =  "Ed25519"
+
       def sign(unsigned: Array[Byte], secretKey: PrivateKey[Ed25519Sig]): F[CryptoSignature[Ed25519Sig]] =
         F.delay(impl.sign(unsigned, secretKey))
 


### PR DESCRIPTION
removes useless tag evidence.

removes cached thread local cipher instances. This can go wrong and cause mem leaks + also keeps cached instances of expanded cryptographic keys.

The latter is pretty bad if it happens under the hood and under the nose of users.