### PR TITLE
Upgrade: cats 2.0.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,6 @@ before_install:
 scala:
   - 2.13.0
   - 2.12.10
-  - 2.11.12
 
 before_cache:
   - find $HOME/.sbt -name "*.lock" -type f -delete

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ before_install:
 
 scala:
   - 2.13.0
-  - 2.12.8
+  - 2.12.10
   - 2.11.12
 
 before_cache:
@@ -41,12 +41,12 @@ script:
   - bash sodium_setup.sh
   - sbt ++$TRAVIS_SCALA_VERSION clean
   - sbt ++$TRAVIS_SCALA_VERSION test
-  - test $TRAVIS_SCALA_VERSION != "2.12.8" || sbt ++$TRAVIS_SCALA_VERSION tut
-  - test $TRAVIS_SCALA_VERSION != "2.12.8" || sbt ++$TRAVIS_SCALA_VERSION microsite/makeMicrosite
+  - test $TRAVIS_SCALA_VERSION != "2.12.10" || sbt ++$TRAVIS_SCALA_VERSION tut
+  - test $TRAVIS_SCALA_VERSION != "2.12.10" || sbt ++$TRAVIS_SCALA_VERSION microsite/makeMicrosite
 
 after_success:
 - test $TRAVIS_PULL_REQUEST == "false" && test $TRAVIS_BRANCH == "master" && test $TRAVIS_REPO_SLUG == "jmcardon/tsec" && sbt ++$TRAVIS_SCALA_VERSION publish
-- test $TRAVIS_PULL_REQUEST == "false" && test $TRAVIS_BRANCH == "master" && test $TRAVIS_REPO_SLUG == "jmcardon/tsec" && test $TRAVIS_SCALA_VERSION == "2.12.8" && sbt ++$TRAVIS_SCALA_VERSION microsite/makeMicrosite
+- test $TRAVIS_PULL_REQUEST == "false" && test $TRAVIS_BRANCH == "master" && test $TRAVIS_REPO_SLUG == "jmcardon/tsec" && test $TRAVIS_SCALA_VERSION == "2.12.10" && sbt ++$TRAVIS_SCALA_VERSION microsite/makeMicrosite
 
 deploy:
   provider: pages

--- a/build.sbt
+++ b/build.sbt
@@ -121,7 +121,7 @@ lazy val commonSettings = Seq(
   ),
   organization in ThisBuild := "io.github.jmcardon",
   scalaVersion := "2.12.10",
-  crossScalaVersions := Seq("2.13.0", "2.12.10", "2.11.12"),
+  crossScalaVersions := Seq("2.13.0", "2.12.10"),
   fork in test := true,
   fork in run := true,
   scalacOptions in (Compile, doc) ++= Seq(

--- a/build.sbt
+++ b/build.sbt
@@ -120,8 +120,8 @@ lazy val commonSettings = Seq(
     Libraries.fs2IO
   ),
   organization in ThisBuild := "io.github.jmcardon",
-  scalaVersion := "2.12.8",
-  crossScalaVersions := Seq("2.13.0", "2.12.8", "2.11.12"),
+  scalaVersion := "2.12.10",
+  crossScalaVersions := Seq("2.13.0", "2.12.10", "2.11.12"),
   fork in test := true,
   fork in run := true,
   scalacOptions in (Compile, doc) ++= Seq(

--- a/jwt-core/src/main/scala/tsec/jwt/JWTClaims.scala
+++ b/jwt-core/src/main/scala/tsec/jwt/JWTClaims.scala
@@ -298,7 +298,7 @@ object JWTClaims extends JWSSerializer[JWTClaims] {
 
   }
 
-  def serializeToUtf8(body: JWTClaims): Array[Byte] = JWTPrinter.pretty(body.asJson).getBytes(StandardCharsets.UTF_8)
+  def serializeToUtf8(body: JWTClaims): Array[Byte] = JWTPrinter.print(body.asJson).getBytes(StandardCharsets.UTF_8)
 
   def fromUtf8Bytes(array: Array[Byte]): Either[Error, JWTClaims] =
     decode[JWTClaims](new String(array, StandardCharsets.UTF_8))

--- a/jwt-mac/src/main/scala/tsec/jws/mac/JWSMacHeader.scala
+++ b/jwt-mac/src/main/scala/tsec/jws/mac/JWSMacHeader.scala
@@ -26,7 +26,7 @@ sealed abstract case class JWSMacHeader[A](
     critical: Option[NonEmptyList[String]] = None //Headers not to ignore, they must be understood by the JWT implementation
 )(implicit val algorithm: JWTMacAlgo[A])
     extends JWSHeader[A] {
-  def toJsonString: String = jwt.JWTPrinter.pretty(this.asJson)
+  def toJsonString: String = jwt.JWTPrinter.print(this.asJson)
 }
 
 object JWSMacHeader {
@@ -83,7 +83,7 @@ object JWSMacHeader {
       e: Encoder[JWSMacHeader[A]]
   ): JWSSerializer[JWSMacHeader[A]] =
     new JWSSerializer[JWSMacHeader[A]] {
-      def serializeToUtf8(body: JWSMacHeader[A]): Array[Byte] = jwt.JWTPrinter.pretty(body.asJson).utf8Bytes
+      def serializeToUtf8(body: JWSMacHeader[A]): Array[Byte] = jwt.JWTPrinter.print(body.asJson).utf8Bytes
 
       def fromUtf8Bytes(array: Array[Byte]): Either[Error, JWSMacHeader[A]] =
         io.circe.parser.decode[JWSMacHeader[A]](array.toUtf8String)

--- a/jwt-sig/src/main/scala/tsec/jws/signature/JWSSignedHeader.scala
+++ b/jwt-sig/src/main/scala/tsec/jws/signature/JWSSignedHeader.scala
@@ -101,7 +101,7 @@ object JWSSignedHeader {
     def fromUtf8Bytes(array: Array[Byte]): Either[Error, JWSSignedHeader[A]] =
       io.circe.parser.decode[JWSSignedHeader[A]](array.toUtf8String)
 
-    def serializeToUtf8(body: JWSSignedHeader[A]): Array[Byte] = jwt.JWTPrinter.pretty(body.asJson).utf8Bytes
+    def serializeToUtf8(body: JWSSignedHeader[A]): Array[Byte] = jwt.JWTPrinter.print(body.asJson).utf8Bytes
   }
 
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -3,16 +3,16 @@ import sbt._
 object Dependencies {
 
   object Versions {
-    val circeV        = "0.12.0-M3"
-    val catsV         = "2.0.0-M4"
+    val circeV        = "0.12.1"
+    val catsV         = "2.0.0"
     val bouncyCastleV = "1.62"
     val sCryptV       = "1.4.0"
     val scalaTestV    = "3.1.0-SNAP13"
     val scalaTestPlusV= "1.0.0-SNAP8"
-    val http4sV       = "0.21.0-M1"
+    val http4sV       = "0.21.0-M4"
     val scalacheckV   = "1.14.0"
     val commonsCodecV = "1.12"
-    val fs2Version    = "1.1.0-M1"
+    val fs2Version    = "2.0.0"
     val log4sV        = "1.8.2"
   }
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -9,7 +9,7 @@ object Dependencies {
     val sCryptV       = "1.4.0"        //https://github.com/wg/scrypt/releases
     val scalaTestV    = "3.1.0-SNAP13" //https://github.com/scalatest/scalatest/releases
     val scalaTestPlusV= "1.0.0-SNAP8"  //https://github.com/scalatest/scalatestplus-scalacheck
-    val http4sV       = "0.21.0-M4"    //https://github.com/http4s/http4s/releases
+    val http4sV       = "0.21.0-M5"    //https://github.com/http4s/http4s/releases
     val scalacheckV   = "1.14.0"       //https://github.com/typelevel/scalacheck/releases
     val commonsCodecV = "1.12"         //https://github.com/apache/commons-codec/releases
     val fs2Version    = "2.0.0"        //https://github.com/functional-streams-for-scala/fs2/releases

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -3,17 +3,17 @@ import sbt._
 object Dependencies {
 
   object Versions {
-    val circeV        = "0.12.1"
-    val catsV         = "2.0.0"
-    val bouncyCastleV = "1.62"
-    val sCryptV       = "1.4.0"
-    val scalaTestV    = "3.1.0-SNAP13"
-    val scalaTestPlusV= "1.0.0-SNAP8"
-    val http4sV       = "0.21.0-M4"
-    val scalacheckV   = "1.14.0"
-    val commonsCodecV = "1.12"
-    val fs2Version    = "2.0.0"
-    val log4sV        = "1.8.2"
+    val circeV        = "0.12.1"       //https://github.com/circe/circe/releases
+    val catsV         = "2.0.0"        //https://github.com/typelevel/cats/releases
+    val bouncyCastleV = "1.62"         //https://github.com/bcgit/bc-java/releases
+    val sCryptV       = "1.4.0"        //https://github.com/wg/scrypt/releases
+    val scalaTestV    = "3.1.0-SNAP13" //https://github.com/scalatest/scalatest/releases
+    val scalaTestPlusV= "1.0.0-SNAP8"  //https://github.com/scalatest/scalatestplus-scalacheck
+    val http4sV       = "0.21.0-M4"    //https://github.com/http4s/http4s/releases
+    val scalacheckV   = "1.14.0"       //https://github.com/typelevel/scalacheck/releases
+    val commonsCodecV = "1.12"         //https://github.com/apache/commons-codec/releases
+    val fs2Version    = "2.0.0"        //https://github.com/functional-streams-for-scala/fs2/releases
+    val log4sV        = "1.8.2"        //https://github.com/Log4s/log4s
   }
 
   object Libraries {

--- a/tsec-http4s/src/main/scala/tsec/authentication/EncryptedCookieAuthenticator.scala
+++ b/tsec-http4s/src/main/scala/tsec/authentication/EncryptedCookieAuthenticator.scala
@@ -411,7 +411,7 @@ object EncryptedCookieAuthenticator {
           now      <- F.delay(Instant.now())
           expiry      = now.plusSeconds(settings.expiryDuration.toSeconds)
           lastTouched = settings.maxIdle.map(_ => now)
-          messageBody = AuthEncryptedCookie.Internal(cookieId, body, expiry, lastTouched).asJson.pretty(JWTPrinter)
+          messageBody = AuthEncryptedCookie.Internal(cookieId, body, expiry, lastTouched).asJson.printWith(JWTPrinter)
           encrypted <- AEADCookieEncryptor.signAndEncrypt[F, A](messageBody, generateAAD(messageBody), key)
         } yield AuthEncryptedCookie.build[A, I](cookieId, encrypted, body, expiry, lastTouched, settings)
 
@@ -425,7 +425,7 @@ object EncryptedCookieAuthenticator {
         val serialized = AuthEncryptedCookie
           .Internal(authenticator.id, authenticator.identity, authenticator.expiry, authenticator.lastTouched)
           .asJson
-          .pretty(JWTPrinter)
+          .printWith(JWTPrinter)
         for {
           encrypted <- AEADCookieEncryptor.signAndEncrypt[F, A](serialized, generateAAD(serialized), key)
         } yield authenticator.copy[A, I](content = encrypted)

--- a/tsec-http4s/src/main/scala/tsec/authentication/internal/PartialStatelessJWTAuth.scala
+++ b/tsec-http4s/src/main/scala/tsec/authentication/internal/PartialStatelessJWTAuth.scala
@@ -59,7 +59,7 @@ private[tsec] abstract class PartialStatelessJWTAuth[F[_], I: Decoder: Encoder, 
       cookieId <- F.delay(SecureRandomId.Interactive.generate)
       expiryTime  = now.plusSeconds(expiry.toSeconds)
       lastTouched = touch(now)
-      subj        = Some(body.asJson.pretty(JWTPrinter))
+      subj        = Some(body.asJson.printWith(JWTPrinter))
       claims = JWTClaims(
         issuedAt = Some(now),
         subject = subj,


### PR DESCRIPTION
Only non-stable library is http4s. 

Had to drop 2.11 support because both http4s and circe dropped it.