### PR TITLE
fix println

### DIFF
--- a/jwt-sig/src/main/scala/tsec/jws/signature/JWSSigCV.scala
+++ b/jwt-sig/src/main/scala/tsec/jws/signature/JWSSigCV.scala
@@ -104,7 +104,7 @@ sealed abstract class JWSSigCV[F[_], A](
         providedBytes <- base64UrlSafeF(split(2))
         sigExtract    <- jwsSigAlgo.concatToJCA[F](providedBytes)
         headerBytes   <- base64UrlSafeF(split(0))
-        header        <- M.fromEither(hs.fromUtf8Bytes(headerBytes).left.map(_ => {println("kekistan2"); defaultError}))
+        header        <- M.fromEither(hs.fromUtf8Bytes(headerBytes).left.map(_ => defaultError))
         bool          <- sigDSL.verifyCert(toSign, CryptoSignature[A](sigExtract), cert)
         body <- M.ensure(M.fromEither(JWTClaims.fromB64URL(split(1))))(defaultError)(
           claims => bool && claims.isAfterNBF(now) && claims.isNotExpired(now) && claims.isValidIssued(now)


### PR DESCRIPTION
println is synchronized and I assume it was an accident to leave this in.
also since it's embedding a side effect within an F algebra inside an map statement it's not the correct way to model an effect.