### PR TITLE
http4s 0.23 support

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -99,6 +99,9 @@ def scalacOptionsForVersion(scalaVersion: String): Seq[String] = {
     "-language:postfixOps"
   )
   val versionOpts: Seq[String] = CrossVersion.partialVersion(scalaVersion) match {
+    case Some((3, _)) => Seq(
+      "-Ykind-projector",
+    )
     case Some((2, major)) if major < 13 => Seq(
       "-Ywarn-adapted-args",
       "-Ywarn-inaccessible",
@@ -121,7 +124,7 @@ lazy val commonSettings = Seq(
   ),
   ThisBuild / organization := "io.github.jmcardon",
   scalaVersion := crossScalaVersions.value.last,
-  crossScalaVersions := Seq("2.12.13", "2.13.5", "3.0.0"),
+  crossScalaVersions := Seq("2.12.13", "2.13.6", "3.0.1"),
   Test / fork := true,
   run / fork := true,
   // doc / scalacOptions ++= Seq(
@@ -189,7 +192,7 @@ lazy val root = Project(id = "tsec", base = file("."))
     jwtMac,
     jwtSig,
     passwordHashers,
-    // http4s,
+    http4s,
     // microsite,
     oauth2,
     // bench,
@@ -330,7 +333,7 @@ lazy val oauth2 = Project(id = "tsec-oauth2", base = file("oauth2"))
   .settings(commonSettings)
   .dependsOn(common % "compile->compile;test->test")
   .settings(noPublishSettings)
-/*
+
 lazy val http4s = Project(id = "tsec-http4s", base = file("tsec-http4s"))
   .settings(commonSettings)
   .settings(jwtCommonLibs)
@@ -347,7 +350,6 @@ lazy val http4s = Project(id = "tsec-http4s", base = file("tsec-http4s"))
     jwtMac
   )
   .settings(releaseSettings)
-*/
 
 lazy val libsodium = Project(id = "tsec-libsodium", base = file("tsec-libsodium"))
   .settings(commonSettings)

--- a/common/src/main/scala/tsec/common/ManagedRandom.scala
+++ b/common/src/main/scala/tsec/common/ManagedRandom.scala
@@ -10,7 +10,8 @@ trait ManagedRandom {
     * [[https://tersesystems.com/2015/12/17/the-right-way-to-use-securerandom/]]
     */
   private[tsec] val cachedRand: SecureRandom = {
-    val r = SecureRandom.getInstance(if ( scala.util.Properties.isWin ) ManagedRandom.WinRandom else ManagedRandom.UnixURandom)
+    val r =
+      SecureRandom.getInstance(if (scala.util.Properties.isWin) ManagedRandom.WinRandom else ManagedRandom.UnixURandom)
     r.nextBytes(new Array[Byte](20)) //Force reseed
     r
   }
@@ -20,6 +21,6 @@ trait ManagedRandom {
 }
 
 object ManagedRandom {
-  private[ManagedRandom] val WinRandom = "Windows-PRNG"
+  private[ManagedRandom] val WinRandom   = "Windows-PRNG"
   private[ManagedRandom] val UnixURandom = "NativePRNGNonBlocking"
 }

--- a/common/src/main/scala/tsec/common/ManagedRandom.scala
+++ b/common/src/main/scala/tsec/common/ManagedRandom.scala
@@ -10,7 +10,7 @@ trait ManagedRandom {
     * [[https://tersesystems.com/2015/12/17/the-right-way-to-use-securerandom/]]
     */
   private[tsec] val cachedRand: SecureRandom = {
-    val r = SecureRandom.getInstance(ManagedRandom.UnixURandom)
+    val r = SecureRandom.getInstance(if ( scala.util.Properties.isWin ) ManagedRandom.WinRandom else ManagedRandom.UnixURandom)
     r.nextBytes(new Array[Byte](20)) //Force reseed
     r
   }
@@ -20,5 +20,6 @@ trait ManagedRandom {
 }
 
 object ManagedRandom {
+  private[ManagedRandom] val WinRandom = "Windows-PRNG"
   private[ManagedRandom] val UnixURandom = "NativePRNGNonBlocking"
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -3,17 +3,17 @@ import sbt._
 object Dependencies {
 
   object Versions {
-    val circeV        = "0.14.0-M7"   //https://github.com/circe/circe/releases
+    val circeV        = "0.14.1"   //https://github.com/circe/circe/releases
     val catsV         = "2.6.1"        //https://github.com/typelevel/cats/releases
     val bouncyCastleV = "1.68"         //https://github.com/bcgit/bc-java/releases
     val sCryptV       = "1.4.0"        //https://github.com/wg/scrypt/releases
     val scalaTestV    = "3.2.9"      //https://github.com/scalatest/scalatest/releases
     val scalaTestPlusV= "3.2.9.0"  //https://github.com/scalatest/scalatestplus-scalacheck
-    val http4sV       = "0.23.0-M1"   //https://github.com/http4s/http4s/releases
+    val http4sV       = "0.23.1"   //https://github.com/http4s/http4s/releases
     val scalacheckV   = "1.15.4"       //https://github.com/typelevel/scalacheck/releases
     val commonsCodecV = "1.15"         //https://github.com/apache/commons-codec/releases
     val fs2Version    = "3.0.3"        //https://github.com/functional-streams-for-scala/fs2/releases
-    val log4sV        = "1.9.0"        //https://github.com/Log4s/log4s
+    val log4sV        = "1.10.0"        //https://github.com/Log4s/log4s
   }
 
   object Libraries {

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 1.5.1
+sbt.version = 1.5.5

--- a/tsec-http4s/src/main/scala/tsec/authentication/EncryptedCookieAuthenticator.scala
+++ b/tsec-http4s/src/main/scala/tsec/authentication/EncryptedCookieAuthenticator.scala
@@ -2,14 +2,13 @@ package tsec.authentication
 
 import java.time.Instant
 import java.util.UUID
-
 import cats.data.OptionT
 import cats.effect.Sync
 import cats.syntax.all._
-import io.circe.generic.auto._
+import io.circe.Json
 import io.circe.parser.decode
 import io.circe.syntax._
-import io.circe.{Decoder, Encoder}
+import io.circe.{Encoder, Decoder}
 import org.http4s._
 import tsec.cipher.symmetric.{IvGen, _}
 import tsec.cipher.symmetric.jca._
@@ -70,18 +69,18 @@ final case class AuthEncryptedCookie[A, Id](
     httpOnly: Boolean = true,
     domain: Option[String] = None,
     path: Option[String] = None,
-    sameSite: SameSite = SameSite.Lax,
+    sameSite: SameSite = org.http4s.SameSite.Lax,
     extension: Option[String] = None
 ) {
 
-  def toCookie = ResponseCookie(
+  def toCookie = org.http4s.ResponseCookie(
     name,
     content,
     Some(HttpDate.unsafeFromInstant(expiry)),
     None,
     domain,
     path,
-    sameSite,
+    Some(sameSite),
     secure,
     httpOnly,
     extension
@@ -90,13 +89,19 @@ final case class AuthEncryptedCookie[A, Id](
 
 object AuthEncryptedCookie {
 
-  implicit def auth[A, Id] = new AuthToken[AuthEncryptedCookie[A, Id]] {
+  implicit def auth[A, Id]: AuthToken[AuthEncryptedCookie[A, Id]] = new AuthToken[AuthEncryptedCookie[A, Id]] {
     def expiry(a: AuthEncryptedCookie[A, Id]): Instant = a.expiry
 
     def lastTouched(a: AuthEncryptedCookie[A, Id]): Option[Instant] = a.lastTouched
   }
 
   final case class Internal[Id](id: UUID, messageId: Id, expiry: Instant, lastTouched: Option[Instant])
+
+  object Internal {
+    import io.circe.generic.semiauto._
+    implicit def decoder[T : Decoder]: Decoder[Internal[T]] = deriveDecoder[Internal[T]]
+    implicit def encoder[T : Encoder]: Encoder[Internal[T]] = deriveEncoder[Internal[T]]
+  }
 
   def build[A, Id](
       id: UUID,
@@ -415,7 +420,8 @@ object EncryptedCookieAuthenticator {
           now      <- F.delay(Instant.now())
           expiry      = now.plusSeconds(settings.expiryDuration.toSeconds)
           lastTouched = settings.maxIdle.map(_ => now)
-          messageBody = AuthEncryptedCookie.Internal(cookieId, body, expiry, lastTouched).asJson.printWith(JWTPrinter)
+          messageBodyJson = AuthEncryptedCookie.Internal(cookieId, body, expiry, lastTouched).asJson : Json
+          messageBody = messageBodyJson.printWith(JWTPrinter)
           encrypted <- AEADCookieEncryptor.signAndEncrypt[F, A](messageBody, generateAAD(messageBody), key)
         } yield AuthEncryptedCookie.build[A, I](cookieId, encrypted, body, expiry, lastTouched, settings)
 

--- a/tsec-http4s/src/main/scala/tsec/authentication/EncryptedCookieAuthenticator.scala
+++ b/tsec-http4s/src/main/scala/tsec/authentication/EncryptedCookieAuthenticator.scala
@@ -8,7 +8,7 @@ import cats.syntax.all._
 import io.circe.Json
 import io.circe.parser.decode
 import io.circe.syntax._
-import io.circe.{Encoder, Decoder}
+import io.circe.{Decoder, Encoder}
 import org.http4s._
 import tsec.cipher.symmetric.{IvGen, _}
 import tsec.cipher.symmetric.jca._
@@ -99,8 +99,8 @@ object AuthEncryptedCookie {
 
   object Internal {
     import io.circe.generic.semiauto._
-    implicit def decoder[T : Decoder]: Decoder[Internal[T]] = deriveDecoder[Internal[T]]
-    implicit def encoder[T : Encoder]: Encoder[Internal[T]] = deriveEncoder[Internal[T]]
+    implicit def decoder[T: Decoder]: Decoder[Internal[T]] = deriveDecoder[Internal[T]]
+    implicit def encoder[T: Encoder]: Encoder[Internal[T]] = deriveEncoder[Internal[T]]
   }
 
   def build[A, Id](
@@ -418,10 +418,10 @@ object EncryptedCookieAuthenticator {
         for {
           cookieId <- F.delay(UUID.randomUUID())
           now      <- F.delay(Instant.now())
-          expiry      = now.plusSeconds(settings.expiryDuration.toSeconds)
-          lastTouched = settings.maxIdle.map(_ => now)
-          messageBodyJson = AuthEncryptedCookie.Internal(cookieId, body, expiry, lastTouched).asJson : Json
-          messageBody = messageBodyJson.printWith(JWTPrinter)
+          expiry          = now.plusSeconds(settings.expiryDuration.toSeconds)
+          lastTouched     = settings.maxIdle.map(_ => now)
+          messageBodyJson = AuthEncryptedCookie.Internal(cookieId, body, expiry, lastTouched).asJson: Json
+          messageBody     = messageBodyJson.printWith(JWTPrinter)
           encrypted <- AEADCookieEncryptor.signAndEncrypt[F, A](messageBody, generateAAD(messageBody), key)
         } yield AuthEncryptedCookie.build[A, I](cookieId, encrypted, body, expiry, lastTouched, settings)
 

--- a/tsec-http4s/src/main/scala/tsec/authentication/JWTAuthenticator.scala
+++ b/tsec-http4s/src/main/scala/tsec/authentication/JWTAuthenticator.scala
@@ -5,8 +5,8 @@ import cats.data.OptionT
 import cats.effect.Sync
 import cats.instances.string._
 import cats.syntax.all._
-import io.circe.{Encoder, Decoder}
-import org.http4s.{Request, Header, ResponseCookie, Response, HttpDate}
+import io.circe.{Decoder, Encoder}
+import org.http4s.{Header, HttpDate, Request, Response, ResponseCookie}
 import org.typelevel.ci.CIString
 import tsec.authentication.internal._
 import tsec.common._

--- a/tsec-http4s/src/main/scala/tsec/authentication/JWTAuthenticator.scala
+++ b/tsec-http4s/src/main/scala/tsec/authentication/JWTAuthenticator.scala
@@ -1,19 +1,18 @@
 package tsec.authentication
 
 import java.time.Instant
-
 import cats.data.OptionT
 import cats.effect.Sync
 import cats.instances.string._
 import cats.syntax.all._
-import io.circe.{Decoder, Encoder}
-import org.http4s.util.CaseInsensitiveString
-import org.http4s.{Header, HttpDate, Request, Response, ResponseCookie}
+import io.circe.{Encoder, Decoder}
+import org.http4s.{Request, Header, ResponseCookie, Response, HttpDate}
+import org.typelevel.ci.CIString
 import tsec.authentication.internal._
 import tsec.common._
 import tsec.jws.mac._
 import tsec.jwt.algorithms.JWTMacAlgo
-import tsec.mac.jca.{MacSigningKey}
+import tsec.mac.jca.MacSigningKey
 
 import scala.concurrent.duration.FiniteDuration
 
@@ -41,7 +40,7 @@ final case class AugmentedJWT[A, I](
       None,
       settings.domain,
       settings.path,
-      settings.sameSite,
+      Some(settings.sameSite),
       settings.secure,
       settings.httpOnly,
       settings.extension
@@ -239,12 +238,12 @@ object JWTAuthenticator {
   ) = r.putHeaders(buildBearerAuthHeader(JWTMac.toEncodedString(a.jwt)))
 
   private[tsec] def extractFromHeader[F[_]](headerName: String)(r: Request[F]): Option[String] =
-    r.headers.get(CaseInsensitiveString(headerName)).map(_.value)
+    r.headers.get(CIString(headerName)).map(_.head.value)
 
   private[tsec] def embedInHeader[F[_], I, A: JWTMacAlgo](headerName: String)(r: Response[F], a: AugmentedJWT[A, I])(
       implicit cv: JWSMacCV[F, A],
       F: Sync[F]
-  ): Response[F] = r.putHeaders(Header(headerName, JWTMac.toEncodedString(a.jwt)))
+  ): Response[F] = r.putHeaders(Header.Raw(CIString(headerName), JWTMac.toEncodedString(a.jwt)))
 
   private[tsec] def extractFromCookie[F[_]](cookieName: String)(r: Request[F]): Option[String] =
     unliftedCookieFromRequest[F](cookieName, r).map(_.content)

--- a/tsec-http4s/src/main/scala/tsec/authentication/SecuredRequestHandler.scala
+++ b/tsec-http4s/src/main/scala/tsec/authentication/SecuredRequestHandler.scala
@@ -54,7 +54,7 @@ sealed abstract class SecuredRequestHandler[F[_], Identity, User, Auth](
 }
 
 object SecuredRequestHandler {
-  private[authentication] val logger = getLogger("tsec.authentication.SecureRequestHandler")
+  private[authentication] val logger = org.log4s.getLogger("tsec.authentication.SecureRequestHandler")
 
   /** Build our SecuredRequestHandler detecting whether it is rolling window or not **/
   def apply[F[_], Identity, User, Auth](

--- a/tsec-http4s/src/main/scala/tsec/authentication/SignedCookieAuthenticator.scala
+++ b/tsec-http4s/src/main/scala/tsec/authentication/SignedCookieAuthenticator.scala
@@ -157,7 +157,7 @@ final case class AuthenticatedCookie[A, Id](
     None,
     domain,
     path,
-    sameSite,
+    Some(sameSite),
     secure,
     httpOnly,
     extension

--- a/tsec-http4s/src/main/scala/tsec/authentication/package.scala
+++ b/tsec-http4s/src/main/scala/tsec/authentication/package.scala
@@ -251,13 +251,13 @@ package object authentication {
   )
 
   def cookieFromRequest[F[_]: Monad](name: String, request: Request[F]): OptionT[F, RequestCookie] =
-    OptionT.fromOption[F](C.from(request.headers).flatMap(_.values.find(_.name === name)))
+    OptionT.fromOption[F](request.cookies.find(_.name === name))
 
   def unliftedCookieFromRequest[F[_]](name: String, request: Request[F]): Option[RequestCookie] =
-    C.from(request.headers).flatMap(_.values.find(_.name === name))
+    request.cookies.find(_.name === name)
 
   def extractBearerToken[F[_]: Monad](request: Request[F]): Option[String] =
-    request.headers.get(Authorization).flatMap { t =>
+    request.headers.get[Authorization].flatMap { t =>
       t.credentials match {
         case Credentials.Token(scheme, token) if scheme == AuthScheme.Bearer =>
           Some(token)

--- a/tsec-http4s/src/main/scala/tsec/authentication/package.scala
+++ b/tsec-http4s/src/main/scala/tsec/authentication/package.scala
@@ -280,7 +280,6 @@ package object authentication {
         )
   }
 
-
   private[tsec] implicit val InstantLongEncoder: Encoder[Instant] = new Encoder[Instant] {
     def apply(a: Instant): Json = Json.fromLong(a.getEpochSecond)
   }

--- a/tsec-http4s/src/main/scala/tsec/authorization/package.scala
+++ b/tsec-http4s/src/main/scala/tsec/authorization/package.scala
@@ -7,7 +7,7 @@ import scala.reflect.ClassTag
 package object authorization {
 
   type AuthGroup[G] = AuthGroup.Type[G]
-  
+
   object AuthGroup {
     type Type[A] <: Array[A]
 
@@ -23,7 +23,7 @@ package object authorization {
     }
     def fromSeq[G: ClassTag](seq: Seq[G]): AuthGroup[G]       = unsafeApply[G](seq.distinct.toArray)
     def unsafeFromSeq[G: ClassTag](seq: Seq[G]): AuthGroup[G] = unsafeApply(seq.toArray)
-    def empty[G: ClassTag]: AuthGroup[G]           = unsafeApply[G](Array.empty[G])
+    def empty[G: ClassTag]: AuthGroup[G]                      = unsafeApply[G](Array.empty[G])
   }
 
   /** A simple typeclass that allows us to propagate information that is required for authorization */

--- a/tsec-http4s/src/main/scala/tsec/authorization/package.scala
+++ b/tsec-http4s/src/main/scala/tsec/authorization/package.scala
@@ -37,7 +37,7 @@ package object authorization {
 
   type InvalidAuthLevel = InvalidAuthLevelError.type
 
-  final object InvalidAuthLevelError extends TSecError {
+  object InvalidAuthLevelError extends TSecError {
     val cause: String = "The minimum auth level is zero."
   }
 

--- a/tsec-http4s/src/main/scala/tsec/csrf/TSecCSRF.scala
+++ b/tsec-http4s/src/main/scala/tsec/csrf/TSecCSRF.scala
@@ -6,7 +6,6 @@ import java.time.Clock
 import cats.data.{Kleisli, OptionT}
 import cats.effect.Sync
 import cats.syntax.all._
-import org.http4s.util.CaseInsensitiveString
 import org.http4s.{HttpRoutes, Request, Response, ResponseCookie, Status}
 import tsec.authentication.{cookieFromRequest, unliftedCookieFromRequest}
 import tsec.common._
@@ -101,10 +100,10 @@ final class TSecCSRF[F[_], A] private[tsec] (
   private[tsec] def checkCSRF(r: Request[F], service: HttpRoutes[F]): F[Response[F]] =
     (for {
       c1       <- cookieFromRequest[F](cookieName, r)
-      c2       <- OptionT.fromOption[F](r.headers.get(CaseInsensitiveString(headerName)).map(_.value))
+      c2       <- OptionT.fromOption[F](r.headers.get(org.typelevel.ci.CIString(headerName)).map(_.head.value))
       raw1     <- extractRaw(CSRFToken(c1.content))
       raw2     <- extractRaw(CSRFToken(c2))
-      res      <- if (isEqual(raw1, raw2)) service(r) else OptionT.none
+      res: Response[F]      <- if (isEqual(raw1, raw2)) service(r) else OptionT.none
       newToken <- OptionT.liftF(signToken(raw1)) //Generate a new token to guard against BREACH.
     } yield res.addCookie(ResponseCookie(name = cookieName, content = newToken)))
       .getOrElse(Response[F](Status.Unauthorized))

--- a/tsec-http4s/src/main/scala/tsec/csrf/TSecCSRF.scala
+++ b/tsec-http4s/src/main/scala/tsec/csrf/TSecCSRF.scala
@@ -99,12 +99,12 @@ final class TSecCSRF[F[_], A] private[tsec] (
 
   private[tsec] def checkCSRF(r: Request[F], service: HttpRoutes[F]): F[Response[F]] =
     (for {
-      c1       <- cookieFromRequest[F](cookieName, r)
-      c2       <- OptionT.fromOption[F](r.headers.get(org.typelevel.ci.CIString(headerName)).map(_.head.value))
-      raw1     <- extractRaw(CSRFToken(c1.content))
-      raw2     <- extractRaw(CSRFToken(c2))
-      res: Response[F]      <- if (isEqual(raw1, raw2)) service(r) else OptionT.none
-      newToken <- OptionT.liftF(signToken(raw1)) //Generate a new token to guard against BREACH.
+      c1               <- cookieFromRequest[F](cookieName, r)
+      c2               <- OptionT.fromOption[F](r.headers.get(org.typelevel.ci.CIString(headerName)).map(_.head.value))
+      raw1             <- extractRaw(CSRFToken(c1.content))
+      raw2             <- extractRaw(CSRFToken(c2))
+      res: Response[F] <- if (isEqual(raw1, raw2)) service(r) else OptionT.none
+      newToken         <- OptionT.liftF(signToken(raw1)) //Generate a new token to guard against BREACH.
     } yield res.addCookie(ResponseCookie(name = cookieName, content = newToken)))
       .getOrElse(Response[F](Status.Unauthorized))
 

--- a/tsec-http4s/src/main/scala/tsec/csrf/package.scala
+++ b/tsec-http4s/src/main/scala/tsec/csrf/package.scala
@@ -13,7 +13,7 @@ package object csrf {
   object CSRFToken extends ManagedRandom {
     type Token <: String
 
-    def apply(s: String): CSRFToken   = s.asInstanceOf[CSRFToken]
+    def apply(s: String): CSRFToken                 = s.asInstanceOf[CSRFToken]
     def subst[F[_]](value: F[String]): F[CSRFToken] = value.asInstanceOf[F[CSRFToken]]
 
     def generateHexBase(tokenLength: Int = 32): String = {

--- a/tsec-http4s/src/test/scala/tsec/AEADCookieSignerTest.scala
+++ b/tsec-http4s/src/test/scala/tsec/AEADCookieSignerTest.scala
@@ -6,11 +6,11 @@ import tsec.cipher.symmetric.jca._
 import tsec.common._
 import tsec.cookies.AEADCookieEncryptor
 import tsec.keygen.symmetric.SymmetricKeyGen
-
+import cats.effect.unsafe.implicits.global
 class AEADCookieSignerTest extends TestSpec {
 
   def aeadCookieTest[A](implicit api: AESGCM[A], keyGen: SymmetricKeyGen[IO, A, SecretKey]): Unit = {
-    implicit val strategy = api.defaultIvStrategy[IO]
+    implicit val strategy: IvGen[IO, A] = api.defaultIvStrategy[IO]
 
     implicit val instance: AADEncryptor[IO, A, SecretKey] = api.genEncryptor[IO]
 

--- a/tsec-http4s/src/test/scala/tsec/authentication/AuthenticatorSpec.scala
+++ b/tsec-http4s/src/test/scala/tsec/authentication/AuthenticatorSpec.scala
@@ -12,7 +12,7 @@ import org.scalacheck._
 import org.scalatest.BeforeAndAfterEach
 import tsec.TestSpec
 import tsec.authorization.{AuthGroup, AuthorizationInfo, SimpleAuthEnum}
-
+import cats.effect.unsafe.implicits.global
 import scala.collection.mutable
 
 sealed abstract case class DummyRole(repr: String)

--- a/tsec-http4s/src/test/scala/tsec/authentication/AuthorizationTests.scala
+++ b/tsec-http4s/src/test/scala/tsec/authentication/AuthorizationTests.scala
@@ -7,6 +7,7 @@ import org.scalatest.matchers.should.Matchers._
 import tsec.TestSpec
 import tsec.authentication.DummyRole.{Admin, Other}
 import tsec.authorization._
+import cats.effect.unsafe.implicits.global
 
 final case class AuthDummyUser(id: Int, role: DummyRole, authLevel: AuthLevel = AuthLevel.CEO)
 
@@ -79,7 +80,7 @@ class AuthorizationTests extends TestSpec {
 
   behavior of "HierarchyAuth"
 
-  implicit val authInfo = new AuthorizationInfo[IO, AuthLevel, AuthLevel] {
+  implicit val authInfo: AuthorizationInfo[IO, AuthLevel, AuthLevel] = new AuthorizationInfo[IO, AuthLevel, AuthLevel] {
     def fetchInfo(u: AuthLevel): IO[AuthLevel] = IO.pure(u)
   }
 

--- a/tsec-http4s/src/test/scala/tsec/authentication/CSRFSpec.scala
+++ b/tsec-http4s/src/test/scala/tsec/authentication/CSRFSpec.scala
@@ -4,10 +4,12 @@ import cats.data.OptionT
 import cats.effect.IO
 import org.http4s._
 import org.http4s.dsl.io._
+import org.typelevel.ci.CIString
 import tsec.TestSpec
 import tsec.csrf.{CSRFToken, TSecCSRF}
 import tsec.keygen.symmetric.IdKeyGen
 import tsec.mac.jca._
+import cats.effect.unsafe.implicits.global
 
 class CSRFSpec extends TestSpec {
 
@@ -88,7 +90,7 @@ class CSRFSpec extends TestSpec {
       (for {
         token <- OptionT.liftF(tsecCSRF.generateToken)
         res <- tsecCSRF.validate()(dummyService)(
-          dummyRequest.withHeaders(Headers.of(Header(tsecCSRF.headerName, token))).addCookie(tsecCSRF.cookieName, token)
+          dummyRequest.withHeaders(Headers.apply(Header.Raw(CIString(tsecCSRF.headerName), token))).addCookie(tsecCSRF.cookieName, token)
         )
       } yield res).getOrElse(orElse).unsafeRunSync().status mustBe Status.Ok
     }
@@ -112,7 +114,7 @@ class CSRFSpec extends TestSpec {
       (for {
         token <- OptionT.liftF(tsecCSRF.generateToken)
         res <- tsecCSRF.validate()(dummyService)(
-          dummyRequest.withHeaders(Headers.of(Header(tsecCSRF.headerName, token)))
+          dummyRequest.withHeaders(Headers.apply(Header.Raw(CIString(tsecCSRF.headerName), token)))
         )
       } yield res).getOrElse(orElse).unsafeRunSync().status mustBe Status.Unauthorized
     }
@@ -122,7 +124,7 @@ class CSRFSpec extends TestSpec {
         token1 <- OptionT.liftF(tsecCSRF.generateToken)
         token2 <- OptionT.liftF(tsecCSRF.generateToken)
         res <- tsecCSRF.validate()(dummyService)(
-          dummyRequest.withHeaders(Headers.of(Header(tsecCSRF.headerName, token1))).addCookie(tsecCSRF.cookieName, token2)
+          dummyRequest.withHeaders(Headers.apply(Header.Raw(CIString(tsecCSRF.headerName), token1))).addCookie(tsecCSRF.cookieName, token2)
         )
       } yield res).getOrElse(orElse).unsafeRunSync().status mustBe Status.Unauthorized
     }
@@ -132,7 +134,7 @@ class CSRFSpec extends TestSpec {
         token <- OptionT.liftF(tsecCSRF.generateToken)
         raw1  <- tsecCSRF.extractRaw(token)
         res <- tsecCSRF.validate()(dummyService)(
-          dummyRequest.withHeaders(Headers.of(Header(tsecCSRF.headerName, token))).addCookie(tsecCSRF.cookieName, token)
+          dummyRequest.withHeaders(Headers.apply(Header.Raw(CIString(tsecCSRF.headerName), token))).addCookie(tsecCSRF.cookieName, token)
         )
         r    <- OptionT.fromOption[IO](res.cookies.find(_.name == tsecCSRF.cookieName).map(_.content))
         raw2 <- tsecCSRF.extractRaw(CSRFToken(r))
@@ -144,7 +146,7 @@ class CSRFSpec extends TestSpec {
         token1 <- OptionT.liftF(tsecCSRF.generateToken)
         token2 <- OptionT.liftF(tsecCSRF.generateToken)
         res <- tsecCSRF.validate()(dummyService)(
-          dummyRequest.withHeaders(Headers.of(Header(tsecCSRF.headerName, token1))).addCookie(tsecCSRF.cookieName, token2)
+          dummyRequest.withHeaders(Headers.apply(Header.Raw(CIString(tsecCSRF.headerName), token1))).addCookie(tsecCSRF.cookieName, token2)
         )
       } yield res).getOrElse(Response.notFound).unsafeRunSync()
 

--- a/tsec-http4s/src/test/scala/tsec/authentication/CSRFSpec.scala
+++ b/tsec-http4s/src/test/scala/tsec/authentication/CSRFSpec.scala
@@ -72,9 +72,11 @@ class CSRFSpec extends TestSpec {
 
       val (origToken, origRaw, response, newToken, newRaw) =
         (for {
-          t1     <- OptionT.liftF[IO, CSRFToken](tsecCSRF.generateToken)
-          raw1   <- tsecCSRF.extractRaw(t1)
-          resp   <- tsecCSRF.validate()(dummyService)(passThroughRequest.addCookie(RequestCookie(tsecCSRF.cookieName, t1)))
+          t1   <- OptionT.liftF[IO, CSRFToken](tsecCSRF.generateToken)
+          raw1 <- tsecCSRF.extractRaw(t1)
+          resp <- tsecCSRF.validate()(dummyService)(
+            passThroughRequest.addCookie(RequestCookie(tsecCSRF.cookieName, t1))
+          )
           cookie <- OptionT.fromOption[IO](resp.cookies.find(_.name == tsecCSRF.cookieName))
           raw2   <- tsecCSRF.extractRaw(CSRFToken(cookie.content))
         } yield (t1, raw1, resp, CSRFToken(cookie.content), raw2))
@@ -90,7 +92,9 @@ class CSRFSpec extends TestSpec {
       (for {
         token <- OptionT.liftF(tsecCSRF.generateToken)
         res <- tsecCSRF.validate()(dummyService)(
-          dummyRequest.withHeaders(Headers.apply(Header.Raw(CIString(tsecCSRF.headerName), token))).addCookie(tsecCSRF.cookieName, token)
+          dummyRequest
+            .withHeaders(Headers.apply(Header.Raw(CIString(tsecCSRF.headerName), token)))
+            .addCookie(tsecCSRF.cookieName, token)
         )
       } yield res).getOrElse(orElse).unsafeRunSync().status mustBe Status.Ok
     }
@@ -124,7 +128,9 @@ class CSRFSpec extends TestSpec {
         token1 <- OptionT.liftF(tsecCSRF.generateToken)
         token2 <- OptionT.liftF(tsecCSRF.generateToken)
         res <- tsecCSRF.validate()(dummyService)(
-          dummyRequest.withHeaders(Headers.apply(Header.Raw(CIString(tsecCSRF.headerName), token1))).addCookie(tsecCSRF.cookieName, token2)
+          dummyRequest
+            .withHeaders(Headers.apply(Header.Raw(CIString(tsecCSRF.headerName), token1)))
+            .addCookie(tsecCSRF.cookieName, token2)
         )
       } yield res).getOrElse(orElse).unsafeRunSync().status mustBe Status.Unauthorized
     }
@@ -134,7 +140,9 @@ class CSRFSpec extends TestSpec {
         token <- OptionT.liftF(tsecCSRF.generateToken)
         raw1  <- tsecCSRF.extractRaw(token)
         res <- tsecCSRF.validate()(dummyService)(
-          dummyRequest.withHeaders(Headers.apply(Header.Raw(CIString(tsecCSRF.headerName), token))).addCookie(tsecCSRF.cookieName, token)
+          dummyRequest
+            .withHeaders(Headers.apply(Header.Raw(CIString(tsecCSRF.headerName), token)))
+            .addCookie(tsecCSRF.cookieName, token)
         )
         r    <- OptionT.fromOption[IO](res.cookies.find(_.name == tsecCSRF.cookieName).map(_.content))
         raw2 <- tsecCSRF.extractRaw(CSRFToken(r))
@@ -146,7 +154,9 @@ class CSRFSpec extends TestSpec {
         token1 <- OptionT.liftF(tsecCSRF.generateToken)
         token2 <- OptionT.liftF(tsecCSRF.generateToken)
         res <- tsecCSRF.validate()(dummyService)(
-          dummyRequest.withHeaders(Headers.apply(Header.Raw(CIString(tsecCSRF.headerName), token1))).addCookie(tsecCSRF.cookieName, token2)
+          dummyRequest
+            .withHeaders(Headers.apply(Header.Raw(CIString(tsecCSRF.headerName), token1)))
+            .addCookie(tsecCSRF.cookieName, token2)
         )
       } yield res).getOrElse(Response.notFound).unsafeRunSync()
 

--- a/tsec-http4s/src/test/scala/tsec/authentication/EncryptedCookieAuthenticatorSpec.scala
+++ b/tsec-http4s/src/test/scala/tsec/authentication/EncryptedCookieAuthenticatorSpec.scala
@@ -8,9 +8,9 @@ import cats.syntax.either._
 import io.circe.generic.auto._
 import io.circe.parser.decode
 import org.http4s.headers.`Set-Cookie`
-import org.http4s.{Response, RequestCookie, Request}
+import org.http4s.{Request, RequestCookie, Response}
 import tsec.cipher.symmetric.jca._
-import tsec.cookies.{AEADCookieEncryptor, AEADCookie}
+import tsec.cookies.{AEADCookie, AEADCookieEncryptor}
 import tsec.keygen.symmetric.IdKeyGen
 
 import scala.concurrent.duration._
@@ -39,7 +39,7 @@ class EncryptedCookieAuthenticatorSpec extends RequestAuthenticatorSpec {
       store: BackingStore[IO, UUID, AuthEncryptedCookie[A, Int]]
   ): AuthSpecTester[AuthEncryptedCookie[A, Int]] = {
     implicit val instance: AADEncryptor[IO, A, SecretKey] = cipherAPI.genEncryptor[IO]
-    implicit val stategy: IvGen[IO, A] = cipherAPI.defaultIvStrategy[IO]
+    implicit val stategy: IvGen[IO, A]                    = cipherAPI.defaultIvStrategy[IO]
 
     val dummyStore = dummyBackingStore[IO, Int, DummyUser](_.id)
     val authenticator = EncryptedCookieAuthenticator.withBackingStore[IO, Int, DummyUser, A](
@@ -84,7 +84,7 @@ class EncryptedCookieAuthenticatorSpec extends RequestAuthenticatorSpec {
       idKeyGen: IdKeyGen[A, SecretKey]
   ): AuthSpecTester[AuthEncryptedCookie[A, Int]] = {
     implicit val instance: AADEncryptor[IO, A, SecretKey] = cipherAPI.genEncryptor[IO]
-    implicit val stategy: IvGen[IO, A] = cipherAPI.defaultIvStrategy[IO]
+    implicit val stategy: IvGen[IO, A]                    = cipherAPI.defaultIvStrategy[IO]
 
     val dummyStore    = dummyBackingStore[IO, Int, DummyUser](_.id)
     val secretKey     = cipherAPI.unsafeGenerateKey

--- a/tsec-http4s/src/test/scala/tsec/authentication/EncryptedCookieAuthenticatorTests.scala
+++ b/tsec-http4s/src/test/scala/tsec/authentication/EncryptedCookieAuthenticatorTests.scala
@@ -87,13 +87,12 @@ class EncryptedCookieAuthenticatorTests extends EncryptedCookieAuthenticatorSpec
       } yield List(cookie, update, renew, refresh, expire)
 
       program.unsafeRunSync().forall { aec =>
-
-        settings.cookieName === aec.name      &&
-        settings.secure     === aec.secure    &&
-        settings.httpOnly   === aec.httpOnly  &&
-        settings.domain     === aec.domain    &&
-        settings.path       === aec.path      &&
-        settings.extension  === aec.extension
+        settings.cookieName === aec.name &&
+        settings.secure === aec.secure &&
+        settings.httpOnly === aec.httpOnly &&
+        settings.domain === aec.domain &&
+        settings.path === aec.path &&
+        settings.extension === aec.extension
 
       } mustBe true
 

--- a/tsec-http4s/src/test/scala/tsec/authentication/EncryptedCookieAuthenticatorTests.scala
+++ b/tsec-http4s/src/test/scala/tsec/authentication/EncryptedCookieAuthenticatorTests.scala
@@ -5,6 +5,7 @@ import java.time.Instant
 import cats.effect.IO
 import tsec.cipher.symmetric._
 import tsec.cipher.symmetric.jca._
+import cats.effect.unsafe.implicits.global
 
 class EncryptedCookieAuthenticatorTests extends EncryptedCookieAuthenticatorSpec {
 

--- a/tsec-http4s/src/test/scala/tsec/authentication/JWTAuthenticatorSpec.scala
+++ b/tsec-http4s/src/test/scala/tsec/authentication/JWTAuthenticatorSpec.scala
@@ -4,6 +4,7 @@ import java.time.Instant
 
 import cats.effect.IO
 import org.http4s.{Header, Request, RequestCookie, SameSite}
+import org.typelevel.ci.CIString
 import tsec.common.SecureRandomId
 import tsec.jws.mac.{JWSMacCV, JWTMac}
 import tsec.jwt.algorithms.JWTMacAlgo
@@ -11,6 +12,7 @@ import tsec.keygen.symmetric.IdKeyGen
 import tsec.mac.jca._
 
 import scala.concurrent.duration._
+import cats.effect.unsafe.implicits.global
 
 class JWTAuthenticatorSpec extends RequestAuthenticatorSpec {
 
@@ -79,7 +81,7 @@ class JWTAuthenticatorSpec extends RequestAuthenticatorSpec {
 
   private[tsec] def embedInHeader[I, A: JWTMacAlgo](headerName: String)(r: Request[IO], a: AugmentedJWT[A, I])(
       implicit cv: JWSMacCV[IO, A]
-  ): Request[IO] = r.putHeaders(Header(headerName, JWTMac.toEncodedString(a.jwt)))
+  ): Request[IO] = r.putHeaders(Header.Raw(CIString(headerName), JWTMac.toEncodedString(a.jwt)))
 
   private[tsec] def embedInCookie[I, A: JWTMacAlgo](
       settings: TSecCookieSettings

--- a/tsec-http4s/src/test/scala/tsec/authentication/JWTAuthenticatorTests.scala
+++ b/tsec-http4s/src/test/scala/tsec/authentication/JWTAuthenticatorTests.scala
@@ -10,6 +10,7 @@ import tsec.jwt.algorithms.JWTMacAlgo
 import tsec.keygen.symmetric.IdKeyGen
 import tsec.mac.MessageAuth
 import tsec.mac.jca._
+import cats.effect.unsafe.implicits.global
 
 class JWTAuthenticatorTests extends JWTAuthenticatorSpec {
 

--- a/tsec-http4s/src/test/scala/tsec/authentication/SignedCookieAuthenticatorTests.scala
+++ b/tsec-http4s/src/test/scala/tsec/authentication/SignedCookieAuthenticatorTests.scala
@@ -14,8 +14,9 @@ import cats.effect.unsafe.implicits.global
 
 class SignedCookieAuthenticatorTests extends RequestAuthenticatorSpec {
 
-  private val cookieName             = "hi"
-  implicit def cookieBackingStore[A]: BackingStore[IO, UUID, AuthenticatedCookie[A, Int]] = dummyBackingStore[IO, UUID, AuthenticatedCookie[A, Int]](_.id)
+  private val cookieName = "hi"
+  implicit def cookieBackingStore[A]: BackingStore[IO, UUID, AuthenticatedCookie[A, Int]] =
+    dummyBackingStore[IO, UUID, AuthenticatedCookie[A, Int]](_.id)
 
   def genAuthenticator[A](
       implicit keyGenerator: IdKeyGen[A, MacSigningKey],

--- a/tsec-http4s/src/test/scala/tsec/authentication/SignedCookieAuthenticatorTests.scala
+++ b/tsec-http4s/src/test/scala/tsec/authentication/SignedCookieAuthenticatorTests.scala
@@ -10,11 +10,12 @@ import tsec.mac.MessageAuth
 import tsec.mac.jca._
 
 import scala.concurrent.duration._
+import cats.effect.unsafe.implicits.global
 
 class SignedCookieAuthenticatorTests extends RequestAuthenticatorSpec {
 
   private val cookieName             = "hi"
-  implicit def cookieBackingStore[A] = dummyBackingStore[IO, UUID, AuthenticatedCookie[A, Int]](_.id)
+  implicit def cookieBackingStore[A]: BackingStore[IO, UUID, AuthenticatedCookie[A, Int]] = dummyBackingStore[IO, UUID, AuthenticatedCookie[A, Int]](_.id)
 
   def genAuthenticator[A](
       implicit keyGenerator: IdKeyGen[A, MacSigningKey],

--- a/tsec-http4s/src/test/scala/tsec/authentication/TSecAuthServiceTests.scala
+++ b/tsec-http4s/src/test/scala/tsec/authentication/TSecAuthServiceTests.scala
@@ -7,6 +7,7 @@ import cats.syntax.semigroupk._
 import org.http4s._
 import org.http4s.implicits._
 import org.http4s.dsl.io._
+import cats.effect.unsafe.implicits.global
 
 class TSecAuthServiceTests extends AuthenticatorSpec {
 


### PR DESCRIPTION
- Compiles for all the crossScalaVersions
- Upgrade Scala 2.13.5 -> 2.13.6 and 3.0.0 -> 3.0.1
- Various things had to be changed to accommodate for different behaviour of Scala 3 such as how circe is handled (`Internal` class), and defining implicit types explicitly.

Please if you can release this asap :-) quite a few people (and organizations) are waiting for this!

Closes #379

