### PR TITLE
Remove deprecation warning

### DIFF
--- a/oauth2/src/main/scala/tsec.oauth2/provider/AccessTokenFetcher.scala
+++ b/oauth2/src/main/scala/tsec.oauth2/provider/AccessTokenFetcher.scala
@@ -20,7 +20,7 @@ object AccessTokenFetcher {
     override def fetch(request: ProtectedResourceRequest): Either[InvalidRequest, FetchResult] = {
       val t      = request.oauthToken orElse (request.accessToken)
       val params = request.params.filter { case (_, v) => !v.isEmpty } map { case (k, v) => (k, v.head) }
-      t.map(s => FetchResult(s, params - ("oauth_token", "access_token")))
+      t.map(s => FetchResult(s, params -- Seq("oauth_token", "access_token")))
         .toRight(InvalidRequest("missing access token"))
     }
   }

--- a/oauth2/src/main/scala/tsec.oauth2/provider/ValidatedRequest.scala
+++ b/oauth2/src/main/scala/tsec.oauth2/provider/ValidatedRequest.scala
@@ -151,7 +151,7 @@ object ValidatedRequest {
   }
 
   private def clientCredentialByAuthorization(s: String): Either[InvalidClient, ClientCredential] =
-    Try(new String(s.base64Bytes, StandardCharsets.UTF_8))
+    Try(new String(s.b64Bytes.getOrElse(Array.empty[Byte]), StandardCharsets.UTF_8))
       .map(_.split(":", 2))
       .getOrElse(Array.empty[String]) match {
       case Array(clientId, clientSecret) =>

--- a/password-hashers/src/main/scala/tsec/passwordhashers/jca/SCryptUtil.scala
+++ b/password-hashers/src/main/scala/tsec/passwordhashers/jca/SCryptUtil.scala
@@ -44,7 +44,7 @@ object SCryptUtil extends ManagedRandom {
     val params   = java.lang.Long.parseLong(parts(2), 16)
     val salt     = Base64.decode(parts(3).toCharArray)
     val derived0 = Base64.decode(parts(4).toCharArray)
-    val N        = Math.pow(2, params >> 16 & 0xffff).toInt
+    val N        = Math.pow(2, (params >> 16 & 0xffff).toDouble).toInt
     val r        = params.toInt >> 8 & 0xff
     val p        = params.toInt & 0xff
     Either.catchNonFatal(JSCrypt.scrypt(passwd, salt, N, r, p, 32)) match {
@@ -95,7 +95,7 @@ object SCryptUtil extends ManagedRandom {
 
     nextBytes(salt)
     val derived = JSCrypt.scrypt(passwd, salt, N, r, p, DerivedKeyLen)
-    val params  = java.lang.Long.toString(log2(N) << 16L | r << 8 | p, 16)
+    val params  = java.lang.Long.toString(log2(N).toLong << 16L | r << 8 | p, 16)
 
     val sb = new java.lang.StringBuilder((salt.length + derived.length) * 2)
     sb.append(SCryptPrepend).append(params).append('$')

--- a/tsec-http4s/src/main/scala/tsec/authentication/SecuredRequestHandler.scala
+++ b/tsec-http4s/src/main/scala/tsec/authentication/SecuredRequestHandler.scala
@@ -22,7 +22,7 @@ sealed abstract class SecuredRequestHandler[F[_], Identity, User, Auth](
   ): HttpRoutes[F] = {
     val middleware = TSecMiddleware(Kleisli(authenticator.extractAndValidate), onNotAuthenticated)
 
-    ME.handleErrorWith(middleware(service)) { e: Throwable =>
+    ME.handleErrorWith(middleware(service)) { (e: Throwable) =>
       SecuredRequestHandler.logger.error(e)("Caught unhandled exception in authenticated service")
       Kleisli.liftF(OptionT.pure(cachedUnauthorized))
     }
@@ -34,7 +34,7 @@ sealed abstract class SecuredRequestHandler[F[_], Identity, User, Auth](
   ): HttpRoutes[F] = {
     val middleware = TSecMiddleware.withFallthrough(Kleisli(authenticator.extractAndValidate), onNotAuthenticated)
 
-    ME.handleErrorWith(middleware(service)) { e: Throwable =>
+    ME.handleErrorWith(middleware(service)) { (e: Throwable) =>
       SecuredRequestHandler.logger.error(e)("Caught unhandled exception in authenticated service")
       Kleisli.liftF(OptionT.pure(cachedUnauthorized))
     }
@@ -45,7 +45,7 @@ sealed abstract class SecuredRequestHandler[F[_], Identity, User, Auth](
   ): HttpRoutes[F] = {
     val middleware = UserAwareService.extract(Kleisli(authenticator.extractAndValidate))
 
-    ME.handleErrorWith(middleware(service)) { e: Throwable =>
+    ME.handleErrorWith(middleware(service)) { (e: Throwable) =>
       SecuredRequestHandler.logger.error(e)("Caught unhandled exception in authenticated service")
       Kleisli.liftF(OptionT.pure(cachedUnauthorized))
     }

--- a/tsec-http4s/src/main/scala/tsec/authentication/package.scala
+++ b/tsec-http4s/src/main/scala/tsec/authentication/package.scala
@@ -61,7 +61,7 @@ package object authentication {
         onNotAuthenticated: Request[F] => F[Response[F]]
     ): TSecMiddleware[F, I, Auth] =
       service => {
-        Kleisli { r: Request[F] =>
+        Kleisli { (r: Request[F]) =>
           OptionT.liftF(
             authedStuff
               .run(r)
@@ -76,7 +76,7 @@ package object authentication {
         onNotAuthenticated: Request[F] => F[Response[F]]
     ): TSecMiddleware[F, I, Auth] =
       service => {
-        Kleisli { r: Request[F] =>
+        Kleisli { (r: Request[F]) =>
           authedStuff
             .run(r)
             .flatMap(service.mapF(o => OptionT.liftF(o.getOrElse(Response[F](Status.NotFound)))).run)
@@ -122,7 +122,7 @@ package object authentication {
         pf: PartialFunction[SecuredRequest[F, I, A], F[Response[F]]],
         onNotAuthorized: SecuredRequest[F, I, A] => OptionT[F, Response[F]]
     )(implicit F: Monad[F]): TSecAuthService[I, A, F] =
-      Kleisli { req: SecuredRequest[F, I, A] =>
+      Kleisli { (req: SecuredRequest[F, I, A]) =>
         OptionT.liftF(auth).flatMap { auth =>
           auth
             .isAuthorized(req)
@@ -140,7 +140,7 @@ package object authentication {
         pf: PartialFunction[SecuredRequest[F, I, A], F[Response[F]]],
         onNotAuthorized: SecuredRequest[F, I, A] => OptionT[F, Response[F]]
     )(implicit F: Monad[F]): TSecAuthService[I, A, F] =
-      Kleisli { req: SecuredRequest[F, I, A] =>
+      Kleisli { (req: SecuredRequest[F, I, A]) =>
         auth
           .isAuthorized(req)
           .flatMap(_ => pf.andThen(OptionT.liftF(_)).applyOrElse(req, Function.const(OptionT.none[F, Response[F]])))
@@ -193,7 +193,7 @@ package object authentication {
         authedStuff: Kleisli[OptionT[F, *], Request[F], SecuredRequest[F, I, Auth]]
     ): UserAwareMiddleware[F, I, Auth] =
       service => {
-        Kleisli { r: Request[F] =>
+        Kleisli { (r: Request[F]) =>
           OptionT.liftF(
             authedStuff
               .map(r => UserAwareRequest(r.request, Some((r.identity, r.authenticator))))

--- a/tsec-http4s/src/main/scala/tsec/csrf/TSecCSRF.scala
+++ b/tsec-http4s/src/main/scala/tsec/csrf/TSecCSRF.scala
@@ -122,7 +122,7 @@ final class TSecCSRF[F[_], A] private[tsec] (
 
   def validate(predicate: Request[F] => Boolean = _.method.isSafe): CSRFMiddleware[F] =
     req =>
-      Kleisli { r: Request[F] =>
+      Kleisli { (r: Request[F]) =>
         filter(predicate, r, req)
     }
 


### PR DESCRIPTION
Remove deprecation warnings for 
1. parentheses are required around the parameter of a lambda.
2. method long2double in object Long is deprecated since 2.13.1: Implicit conversion from Long to Double is dangerous because it loses precision.
3. method << in class Int is deprecated since 2.12.7: shifting a value by a `Long` argument is deprecated (except when the value is a `Long`)
4. method - in trait MapOps is deprecated since 2.13.0: Use -- with an explicit collection
5. method base64Bytes in class JerryStringer is deprecated since 0.0.1-M12: use .b64Bytes functions.