### PR TITLE
Rename enum parameter name

### DIFF
--- a/tsec-http4s/src/main/scala/tsec/authorization/BLPAuthorization.scala
+++ b/tsec-http4s/src/main/scala/tsec/authorization/BLPAuthorization.scala
@@ -20,15 +20,15 @@ trait BLPAuthorization[F[_], A, Auth] extends Authorization[F, A, Auth]
   */
 sealed abstract case class BLPReadAction[F[_], Role, A, Auth](authLevel: Role)(
     implicit authInfo: AuthorizationInfo[F, Role, A],
-    enum: SimpleAuthEnum[Role, Int],
+    authEnum: SimpleAuthEnum[Role, Int],
     F: MonadError[F, Throwable]
 ) extends BLPAuthorization[F, A, Auth] {
   def isAuthorized(
       toAuth: authentication.SecuredRequest[F, A, Auth]
   ): OptionT[F, authentication.SecuredRequest[F, A, Auth]] = {
     val out = authInfo.fetchInfo(toAuth.identity).map { info =>
-      val userAuthLevel = enum.getRepr(info)
-      if (enum.contains(info) && userAuthLevel <= enum.getRepr(authLevel))
+      val userAuthLevel = authEnum.getRepr(info)
+      if (authEnum.contains(info) && userAuthLevel <= authEnum.getRepr(authLevel))
         Some(toAuth)
       else
         None
@@ -40,10 +40,10 @@ sealed abstract case class BLPReadAction[F[_], Role, A, Auth](authLevel: Role)(
 object BLPReadAction {
   def apply[F[_], Role, A, Auth](authLevel: Role)(
       implicit authInfo: AuthorizationInfo[F, Role, A],
-      enum: SimpleAuthEnum[Role, Int],
+      authEnum: SimpleAuthEnum[Role, Int],
       F: MonadError[F, Throwable]
   ): F[BLPReadAction[F, Role, A, Auth]] =
-    if (enum.getRepr(authLevel) < 0)
+    if (authEnum.getRepr(authLevel) < 0)
       F.raiseError(InvalidAuthLevelError)
     else
       F.pure(new BLPReadAction[F, Role, A, Auth](authLevel) {})
@@ -55,15 +55,15 @@ object BLPReadAction {
   */
 sealed abstract case class BLPWriteAction[F[_], Role, A, Auth](authLevel: Role)(
     implicit authInfo: AuthorizationInfo[F, Role, A],
-    enum: SimpleAuthEnum[Role, Int],
+    authEnum: SimpleAuthEnum[Role, Int],
     F: MonadError[F, Throwable]
 ) extends BLPAuthorization[F, A, Auth] {
   def isAuthorized(
       toAuth: authentication.SecuredRequest[F, A, Auth]
   ): OptionT[F, authentication.SecuredRequest[F, A, Auth]] = {
     val out = authInfo.fetchInfo(toAuth.identity).map { info =>
-      val userAuthLevel = enum.getRepr(info)
-      if (enum.contains(info) && userAuthLevel == enum.getRepr(authLevel))
+      val userAuthLevel = authEnum.getRepr(info)
+      if (authEnum.contains(info) && userAuthLevel == authEnum.getRepr(authLevel))
         Some(toAuth)
       else
         None
@@ -75,10 +75,10 @@ sealed abstract case class BLPWriteAction[F[_], Role, A, Auth](authLevel: Role)(
 object BLPWriteAction {
   def apply[F[_], Role, A, Auth](authLevel: Role)(
       implicit authInfo: AuthorizationInfo[F, Role, A],
-      enum: SimpleAuthEnum[Role, Int],
+      authEnum: SimpleAuthEnum[Role, Int],
       F: MonadError[F, Throwable]
   ): F[BLPWriteAction[F, Role, A, Auth]] =
-    if (enum.getRepr(authLevel) < 0)
+    if (authEnum.getRepr(authLevel) < 0)
       F.raiseError(InvalidAuthLevelError)
     else
       F.pure(new BLPWriteAction[F, Role, A, Auth](authLevel) {})

--- a/tsec-http4s/src/main/scala/tsec/authorization/BasicRBAC.scala
+++ b/tsec-http4s/src/main/scala/tsec/authorization/BasicRBAC.scala
@@ -9,7 +9,7 @@ import scala.reflect.ClassTag
 
 sealed abstract case class BasicRBAC[F[_], R, U, Auth](authorized: AuthGroup[R])(
     implicit role: AuthorizationInfo[F, R, U],
-    enum: SimpleAuthEnum[R, String],
+    authEnum: SimpleAuthEnum[R, String],
     F: MonadError[F, Throwable]
 ) extends Authorization[F, U, Auth] {
 
@@ -18,7 +18,7 @@ sealed abstract case class BasicRBAC[F[_], R, U, Auth](authorized: AuthGroup[R])
   ): OptionT[F, authentication.SecuredRequest[F, U, Auth]] =
     OptionT {
       role.fetchInfo(toAuth.identity).map { extractedRole =>
-        if (enum.contains(extractedRole) && authorized.contains(extractedRole))
+        if (authEnum.contains(extractedRole) && authorized.contains(extractedRole))
           Some(toAuth)
         else
           None
@@ -28,7 +28,7 @@ sealed abstract case class BasicRBAC[F[_], R, U, Auth](authorized: AuthGroup[R])
 
 object BasicRBAC {
   def apply[F[_], R: ClassTag, U, Auth](roles: R*)(
-      implicit enum: SimpleAuthEnum[R, String],
+      implicit authEnum: SimpleAuthEnum[R, String],
       role: AuthorizationInfo[F, R, U],
       F: MonadError[F, Throwable]
   ): BasicRBAC[F, R, U, Auth] =
@@ -36,14 +36,14 @@ object BasicRBAC {
 
   def fromGroup[F[_], R: ClassTag, U, Auth](valueSet: AuthGroup[R])(
       implicit role: AuthorizationInfo[F, R, U],
-      enum: SimpleAuthEnum[R, String],
+      authEnum: SimpleAuthEnum[R, String],
       F: MonadError[F, Throwable]
   ): BasicRBAC[F, R, U, Auth] = new BasicRBAC[F, R, U, Auth](valueSet) {}
 
   def all[F[_], R: ClassTag, U, Auth](
-      implicit enum: SimpleAuthEnum[R, String],
+      implicit authEnum: SimpleAuthEnum[R, String],
       role: AuthorizationInfo[F, R, U],
       F: MonadError[F, Throwable]
   ): BasicRBAC[F, R, U, Auth] =
-    new BasicRBAC[F, R, U, Auth](enum.viewAll) {}
+    new BasicRBAC[F, R, U, Auth](authEnum.viewAll) {}
 }

--- a/tsec-http4s/src/main/scala/tsec/authorization/DynamicRBAC.scala
+++ b/tsec-http4s/src/main/scala/tsec/authorization/DynamicRBAC.scala
@@ -7,7 +7,7 @@ import tsec.authentication
 
 case class DynamicRBAC[F[_], Role, U, Auth](dynamic: DynamicAuthGroup[F, Role])(
     implicit authInfo: AuthorizationInfo[F, Role, U],
-    enum: SimpleAuthEnum[Role, String],
+    authEnum: SimpleAuthEnum[Role, String],
     F: MonadError[F, Throwable]
 ) extends Authorization[F, U, Auth] {
   def isAuthorized(
@@ -17,7 +17,7 @@ case class DynamicRBAC[F[_], Role, U, Auth](dynamic: DynamicAuthGroup[F, Role])(
       info  <- authInfo.fetchInfo(toAuth.identity)
       group <- dynamic.fetchGroupInfo
     } yield {
-      if (enum.contains(info) && group.contains(info))
+      if (authEnum.contains(info) && group.contains(info))
         Some(toAuth)
       else
         None

--- a/tsec-http4s/src/main/scala/tsec/authorization/HierarchyAuth.scala
+++ b/tsec-http4s/src/main/scala/tsec/authorization/HierarchyAuth.scala
@@ -7,7 +7,7 @@ import tsec.authentication
 
 sealed abstract case class HierarchyAuth[F[_], R, U, Auth](authLevel: R)(
     implicit role: AuthorizationInfo[F, R, U],
-    enum: SimpleAuthEnum[R, Int],
+    authEnum: SimpleAuthEnum[R, Int],
     F: MonadError[F, Throwable]
 ) extends Authorization[F, U, Auth] {
 
@@ -16,8 +16,8 @@ sealed abstract case class HierarchyAuth[F[_], R, U, Auth](authLevel: R)(
   ): OptionT[F, authentication.SecuredRequest[F, U, Auth]] =
     OptionT {
       role.fetchInfo(toAuth.identity).map { authRole =>
-        val intRepr = enum.getRepr(authRole)
-        if (0 <= intRepr && intRepr <= enum.getRepr(authLevel) && enum.contains(authRole))
+        val intRepr = authEnum.getRepr(authRole)
+        if (0 <= intRepr && intRepr <= authEnum.getRepr(authLevel) && authEnum.contains(authRole))
           Some(toAuth)
         else
           None


### PR DESCRIPTION
`enum` is now a keyword in scala 3, [see](https://dotty.epfl.ch/docs/internals/syntax.html#regular-keywords)